### PR TITLE
테스트용 몽고디비 세팅 / 스프링 버전 2.5.3으로 다운그레이드

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "2.7.0"
+	id("org.springframework.boot") version "2.5.3"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
@@ -30,6 +30,7 @@ dependencies {
 	implementation("io.springfox:springfox-boot-starter:${swaggerVersion}")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.6")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
@@ -17,9 +17,9 @@ data class User(
 	val tags: List<String> = emptyList(),
 
 	@CreatedDate // TODO: KST 변환방법 알아보기 JAVA TIME Module
-	val createdAt: LocalDateTime = LocalDateTime.MIN, // TODO: modified, created 되는지 테스트해보기
+	val createdAt: LocalDateTime = LocalDateTime.now(), // TODO: modified, created 되는지 테스트해보기
 	@LastModifiedDate
-	val updatedAt: LocalDateTime = LocalDateTime.MIN,
+	val updatedAt: LocalDateTime = LocalDateTime.now(),
 )
 
 enum class LoginType {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Comment.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Comment.kt
@@ -13,7 +13,7 @@ data class Comment (
 	val content: String,
 
 	@CreatedDate
-	val createdAt: LocalDateTime = LocalDateTime.MIN,
+	val createdAt: LocalDateTime = LocalDateTime.now(),
 	@LastModifiedDate
-	val updatedAt: LocalDateTime = LocalDateTime.MIN
+	val updatedAt: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Post.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Post.kt
@@ -4,6 +4,8 @@ import org.bson.types.ObjectId
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
 
@@ -11,6 +13,7 @@ import java.time.LocalDateTime
 data class Post(
 	val id: ObjectId? = null,
 	val content: String,
+	@GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
 	val location: GeoJsonPoint,
 
 	@CreatedDate

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Post.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Post.kt
@@ -14,7 +14,7 @@ data class Post(
 	val location: GeoJsonPoint,
 
 	@CreatedDate
-	val createdAt: LocalDateTime = LocalDateTime.MIN,
+	val createdAt: LocalDateTime = LocalDateTime.now(),
 	@LastModifiedDate
-	val updatedAt: LocalDateTime = LocalDateTime.MIN
+	val updatedAt: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/question/Answer.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/question/Answer.kt
@@ -14,7 +14,7 @@ data class Answer(
 	val content: String,
 
 	@CreatedDate
-	val createdAt: LocalDateTime = LocalDateTime.MIN,
+	val createdAt: LocalDateTime = LocalDateTime.now(),
 	@LastModifiedDate
-	val updatedAt: LocalDateTime = LocalDateTime.MIN
+	val updatedAt: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
@@ -1,0 +1,13 @@
+package kr.mashup.bangwidae.asked.repository
+
+import kr.mashup.bangwidae.asked.model.post.Post
+import org.bson.types.ObjectId
+import org.springframework.data.geo.Distance
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PostRepository : MongoRepository<Post, ObjectId> {
+	fun findAByLocationNear(location: GeoJsonPoint, distance: Distance): List<Post>
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface PostRepository : MongoRepository<Post, ObjectId> {
-	fun findAByLocationNear(location: GeoJsonPoint, distance: Distance): List<Post>
+	fun findByLocationNear(location: GeoJsonPoint, distance: Distance): List<Post>
 }

--- a/src/test/kotlin/kr/mashup/bangwidae/asked/Mock.kt
+++ b/src/test/kotlin/kr/mashup/bangwidae/asked/Mock.kt
@@ -1,0 +1,42 @@
+package kr.mashup.bangwidae.asked
+
+import kr.mashup.bangwidae.asked.model.LoginType
+import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.model.post.Post
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+
+fun mockUser(): User {
+	return User(
+		id = null,
+		nickname = "mock user nickname",
+		loginId = "mock user loginId",
+		password = "mock user password",
+		providerId = "mock user providerId",
+		loginType = LoginType.BASIC,
+		tags = listOf("tag1", "tag2")
+	)
+}
+
+fun mockSinnonhyeonPost(): Post {
+	return Post(
+		id = null,
+		content = "신논현 교보문고 입니다.",
+		location = GeoJsonPoint(127.024099, 37.504030)
+	)
+}
+
+fun mockGangnamPost(): Post {
+	return Post(
+		id = null,
+		content = "강남역 입니다.",
+		location = GeoJsonPoint(127.027926, 37.497175)
+	)
+}
+
+fun mockNonhyeonPost(): Post {
+	return Post(
+		id = null,
+		content = "논현역 입니다.",
+		location = GeoJsonPoint(127.02158470345, 37.511130469556)
+	)
+}

--- a/src/test/kotlin/kr/mashup/bangwidae/asked/MongoDBTests.kt
+++ b/src/test/kotlin/kr/mashup/bangwidae/asked/MongoDBTests.kt
@@ -1,0 +1,72 @@
+package kr.mashup.bangwidae.asked
+
+import kr.mashup.bangwidae.asked.model.post.Post
+import kr.mashup.bangwidae.asked.repository.PostRepository
+import kr.mashup.bangwidae.asked.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.data.geo.Distance
+import org.springframework.data.geo.Metrics
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType
+import org.springframework.data.mongodb.core.index.GeospatialIndex
+import org.springframework.data.mongodb.core.indexOps
+import org.springframework.data.repository.findByIdOrNull
+
+
+@DataMongoTest
+class MongoDbSpringIntegrationTest(
+	@Autowired
+	private val mongoTemplate: MongoTemplate,
+	@Autowired
+	private val userRepository: UserRepository,
+	@Autowired
+	private val postRepository: PostRepository
+) {
+	@Test
+	@DisplayName("유저 저장하고 id로 찾기 몽고 테스트")
+	fun saveAndFindUserTest() {
+		// given
+		val user = mockUser()
+
+		// when
+		val savedUser = userRepository.save(user)
+		val foundUser = userRepository.findByIdOrNull(savedUser.id) ?: throw RuntimeException("mongo user test failed")
+
+		// then
+		assertTrue(savedUser.id == foundUser.id)
+		assertTrue(savedUser.loginId == foundUser.loginId)
+		assertTrue(savedUser.nickname == foundUser.nickname)
+		assertTrue(savedUser.password == foundUser.password)
+		assertTrue(savedUser.tags == foundUser.tags)
+		assertTrue(savedUser.loginType == foundUser.loginType)
+		assertTrue(savedUser.providerId == foundUser.providerId)
+	}
+
+	@Test
+	@DisplayName("강남역에서 신논현역(800m), 논현역(1km 이상) 거리 테스트")
+	fun findNearLocationPostTest() {
+		//given
+		val gangnamPost = mockGangnamPost()
+		val sinnonhyeonPost = mockSinnonhyeonPost()
+		val nonhyeonPost = mockNonhyeonPost()
+
+		//when
+		mongoTemplate.indexOps<Post>().ensureIndex(GeospatialIndex("location").typed(GeoSpatialIndexType.GEO_2DSPHERE))
+		val savedSinnonhyeonPost = postRepository.save(sinnonhyeonPost)
+		val savedNonhyeonPost = postRepository.save(nonhyeonPost)
+		val nearGangnamPostIdList =
+			postRepository.findAByLocationNear(
+				gangnamPost.location,
+				Distance(1.0, Metrics.KILOMETERS)
+			).map { it.id }
+
+		//then
+		assertThat(nearGangnamPostIdList).contains(savedSinnonhyeonPost.id)
+		assertThat(nearGangnamPostIdList).doesNotContain(savedNonhyeonPost.id)
+	}
+}

--- a/src/test/kotlin/kr/mashup/bangwidae/asked/MongoDBTests.kt
+++ b/src/test/kotlin/kr/mashup/bangwidae/asked/MongoDBTests.kt
@@ -60,7 +60,7 @@ class MongoDbSpringIntegrationTest(
 		val savedSinnonhyeonPost = postRepository.save(sinnonhyeonPost)
 		val savedNonhyeonPost = postRepository.save(nonhyeonPost)
 		val nearGangnamPostIdList =
-			postRepository.findAByLocationNear(
+			postRepository.findByLocationNear(
 				gangnamPost.location,
 				Distance(1.0, Metrics.KILOMETERS)
 			).map { it.id }


### PR DESCRIPTION
이슈번호: #11 

- 테스트시 embedded mongo 사용 ( h2 와 유사한..)
- swagger 부터 embedded mongo까지 계속해서 2.6.0 이상이 이슈가 있어 안정성을 위해 2.5.3으로 다운그레이드
- Mock 사용법 정의(method)
- MongoTest 작성
    - 유저 저장하고 id로 찾기 몽고 테스트
    - 강남역에서 신논현역(800m), 논현역(1km 이상) 거리 테스트: 신논현역, 논현역에서 각각 Post를 작성하고, 강남역 위치에서findByLocationNear(1km) 쿼리를 통해 신논현역은 결과로 나오고 논현역은 결과에 나오지 않는 것을 테스트.
    