### PR TITLE
transaction manager 추가

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/MongoConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/MongoConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.mongodb.MongoDatabaseFactory
+import org.springframework.data.mongodb.MongoTransactionManager
 import org.springframework.data.mongodb.config.EnableMongoAuditing
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory
@@ -26,5 +27,10 @@ class MongoConfig {
 	@Bean
 	fun mongoTemplate(mongoFactory: MongoDatabaseFactory): MongoTemplate {
 		return MongoTemplate(mongoFactory)
+	}
+
+	@Bean
+	fun transactionManager(mongoFactory: MongoDatabaseFactory): MongoTransactionManager {
+		return MongoTransactionManager(mongoFactory)
 	}
 }


### PR DESCRIPTION
https://github.com/mash-up-kr/mashup_bangwidae_backend_spring/issues/21

- mongodb standalone에서 replicaset으로 변경 ( 트랜잭션 사용시 필요 )
- transaction manager 설정

Transaction 사용시 주의사항
단순히 하나의 도큐먼트를 읽고쓰고하는 것에 대해서는 atomic을 보장하고, Transaction이 필요한 곳은 여러 도큐먼트들을 다룰때

```
ex) 
val user1 = userRepository.find(1)
val user2 = userRepository.find(2)
val user1.friendList.add(user2)
val user2.friendLIst.add(user1)
userRepository.saveAll(user1, user2)

```

이럴때만 Transactional 사용
