### PR TITLE
Naver Reverse Geocode API 연동 (#25)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2020.0.5")
+    }
+}
+
 val swaggerVersion: String by project
 val javaJwtVersion: String by project
 val kotlinLoggingVersion: String by project
@@ -27,6 +33,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
 	implementation("com.auth0:java-jwt:$javaJwtVersion")
 	implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:${jasyptVersion}")

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "local": {
+    "doridori": "http://localhost:8080"
+  }
+}

--- a/http/place.http
+++ b/http/place.http
@@ -1,0 +1,29 @@
+### 강남역
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=37.504030&longitude=127.024099
+
+### 용인시 수지구
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=37.342296446704&longitude=127.10195655337
+
+### 일반 읍면동
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=37.5666936&longitude=126.9913201
+
+### 일반 읍면동
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=35.2982640&longitude=129.1133567
+
+### 일반 리
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=36.4938906&longitude=128.2439084
+
+### 분당구 정자동 (법정동=행정동)
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=37.3614463&longitude=127.1114893
+
+### 세종시 도담동 (법정동=행정동)
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=36.5008113&longitude=127.2654387
+
+### 세종시 조치원읍 (법정)
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=36.5929071&longitude=127.2923750
+
+### 바다 위
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=37.5666936&longitude=125.9913201
+
+### 도쿄
+GET {{doridori}}/api/v1/place/reverse/geocode?latitude=35.6894875&longitude=139.6917064

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/AskedApplication.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/AskedApplication.kt
@@ -2,7 +2,9 @@ package kr.mashup.bangwidae.asked
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
+@EnableFeignClients
 @SpringBootApplication
 class AskedApplication
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -36,7 +36,8 @@ class SecurityConfig {
             .antMatchers(
                 "actuator/health",
                 "/api/v1/user/join",
-                "/api/v1/auth/login"
+                "/api/v1/auth/login",
+                "/api/v1/place/reverse/geocode",
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
@@ -1,0 +1,29 @@
+package kr.mashup.bangwidae.asked.controller
+
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import kr.mashup.bangwidae.asked.controller.dto.ApiResponse
+import kr.mashup.bangwidae.asked.service.place.PlaceService
+import kr.mashup.bangwidae.asked.service.place.Region
+import org.springframework.web.bind.annotation.*
+
+@Api(tags = ["장소 컨트롤러"])
+@RestController
+@RequestMapping("/api/v1/place")
+class PlaceController(
+    private val placeService: PlaceService,
+) {
+    @ApiOperation("위경도를 주소로 변환합니다")
+    @GetMapping("/reverse/geocode")
+    fun reverseGeocode(
+        @RequestParam latitude: Double,
+        @RequestParam longitude: Double,
+    ): ApiResponse<Region> {
+        return placeService.reverseGeocode(
+            longitude = longitude,
+            latitude = latitude,
+        ).let {
+            ApiResponse.success(it)
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*
 class PlaceController(
     private val placeService: PlaceService,
 ) {
-    @ApiOperation("위경도를 주소로 변환합니다")
+    @ApiOperation("위경도를 주소로 변환")
     @GetMapping("/reverse/geocode")
     fun reverseGeocode(
         @RequestParam latitude: Double,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*
 class PlaceController(
     private val placeService: PlaceService,
 ) {
+    // TODO 필요한 응답 포맷 확인 후 DTO 반환하도록 수정
     @ApiOperation("위경도를 주소로 변환")
     @GetMapping("/reverse/geocode")
     fun reverseGeocode(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
@@ -44,7 +44,20 @@ enum class DoriDoriExceptionType(
         httpStatus = HttpStatus.BAD_REQUEST,
         code = Code.INVALID_PASSWORD_LENGTH,
         message = "비밀번호는 8자리 이상이어야 해요"
-    );
+    ),
+
+    // PLACE
+    INVALID_COUNTRY(
+        httpStatus = HttpStatus.BAD_REQUEST,
+        code = Code.INVALID_COUNTRY,
+        message = "한국에서만 위치 기능을 사용할 수 있어요"
+    ),
+    PLACE_FETCH_FAIL(
+        httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+        code = Code.PLACE_FETCH_FAIL,
+        message = "위치 정보를 받아오지 못했어요"
+    ),
+    ;
 
     object Code {
         const val COMMON_ERROR = "COMMON_ERROR"
@@ -54,5 +67,8 @@ enum class DoriDoriExceptionType(
         const val INVALID_PASSWORD = "INVALID_PASSWORD"
         const val INVALID_PASSWORD_REGEX = "INVALID_PASSWORD_REGEX"
         const val INVALID_PASSWORD_LENGTH = "INVALID_PASSWORD_LENGTH"
+
+        const val INVALID_COUNTRY = "INVALID_COUNTRY"
+        const val PLACE_FETCH_FAIL = "PLACE_FETCH_FAIL"
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapClient.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapClient.kt
@@ -1,0 +1,73 @@
+package kr.mashup.bangwidae.asked.external.map
+
+import org.springframework.stereotype.Component
+
+@Component
+class NaverMapClient(
+    private val naverMapFeignClient: NaverMapFeignClient,
+    private val naverMapProperties: NaverMapProperties,
+) {
+    fun reverseGeocode(longitude: Double, latitude: Double): List<NaverReverseGeocodeResult> {
+        val response = naverMapFeignClient.reverseGeocode(
+            clientId = naverMapProperties.authorization.clientId,
+            clientSecret = naverMapProperties.authorization.clientSecret,
+            coordinates = "${longitude},${latitude}",
+            responseType = "json"
+        )
+
+        return response.results
+    }
+}
+
+data class NaverReverseGeocodeResponse(
+    val status: NaverReverseGeocodeStatus,
+    val results: List<NaverReverseGeocodeResult>,
+)
+
+data class NaverReverseGeocodeStatus(
+    val code: Int,
+    val name: String,
+    val message: String,
+)
+
+data class NaverReverseGeocodeResult(
+    val name: String?,
+    val code: NaverReverseGeocodeCode?,
+    val region: NaverReverseGeocodeRegion?,
+)
+
+data class NaverReverseGeocodeCode(
+    val id: String?,
+    val type: String?,
+    val mappingId: String?,
+)
+
+data class NaverReverseGeocodeRegion(
+    // 국가 코드 최상위 도메인 두 자리 (KR)
+    val area0: NaverReverseGeocodeRegionArea?,
+    // 행정안전부에서 공시된 시/도 명칭
+    val area1: NaverReverseGeocodeRegionArea?,
+    // 행정안전부에서 공시된 시/군/구 명칭
+    val area2: NaverReverseGeocodeRegionArea?,
+    // 행정안전부에서 공시된 읍/면/동 명칭
+    val area3: NaverReverseGeocodeRegionArea?,
+    // 행정안전부에서 공시된 리 명칭
+    val area4: NaverReverseGeocodeRegionArea?,
+)
+
+data class NaverReverseGeocodeRegionArea(
+    val name: String?,
+    val coords: NaverReverseGeocodeCoords?,
+    val alias: String?,
+)
+
+data class NaverReverseGeocodeCoords(
+    val center: NaverReverseGeocodeCenter?,
+)
+
+data class NaverReverseGeocodeCenter(
+    val crs: String?,
+    val x: Double?,
+    val y: Double?,
+)
+

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapClient.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapClient.kt
@@ -15,19 +15,28 @@ class NaverMapClient(
             responseType = "json"
         )
 
-        return response.results
+        // TODO FeignException 을 DoriDoriException 으로
+
+        return response.results!!
     }
 }
 
 data class NaverReverseGeocodeResponse(
-    val status: NaverReverseGeocodeStatus,
-    val results: List<NaverReverseGeocodeResult>,
+    val status: NaverReverseGeocodeStatus?,
+    val results: List<NaverReverseGeocodeResult>?,
+    val error: NaverReverseGeocodeError?,
 )
 
 data class NaverReverseGeocodeStatus(
     val code: Int,
-    val name: String,
-    val message: String,
+    val name: String?,
+    val message: String?,
+)
+
+data class NaverReverseGeocodeError(
+    val errorCode: String,
+    val message: String?,
+    val details: String?,
 )
 
 data class NaverReverseGeocodeResult(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapFeignClient.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapFeignClient.kt
@@ -1,0 +1,17 @@
+package kr.mashup.bangwidae.asked.external.map
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "naver-map", url = "\${map.naver.host}")
+interface NaverMapFeignClient {
+    @GetMapping("/map-reversegeocode/v2/gc")
+    fun reverseGeocode(
+        @RequestHeader("X-NCP-APIGW-API-KEY-ID") clientId: String,
+        @RequestHeader("X-NCP-APIGW-API-KEY") clientSecret: String,
+        @RequestParam("coords") coordinates: String,
+        @RequestParam("output") responseType: String,
+    ): NaverReverseGeocodeResponse
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapProperties.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/external/map/NaverMapProperties.kt
@@ -1,0 +1,22 @@
+package kr.mashup.bangwidae.asked.external.map
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(NaverMapProperties::class)
+class NaverMapPropertiesConfiguration
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "map.naver")
+data class NaverMapProperties(
+    val authorization: Authorization,
+    val host: String,
+) {
+    data class Authorization(
+        val clientId: String,
+        val clientSecret: String,
+    )
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
@@ -15,12 +15,11 @@ class NaverReverseGeocodeConverter(
             latitude = latitude,
         )
 
-        return reverseGeocodeResults
-            .takeIf { it.isNotEmpty() }
-            ?.first()
+        val naverRegion = reverseGeocodeResults
+            .firstOrNull()
             ?.region
             ?.let {
-                Region(
+                NaverRegion(
                     국가 = it.area0?.name,
                     시도 = it.area1?.name,
                     시군구 = it.area2?.name,
@@ -31,5 +30,30 @@ class NaverReverseGeocodeConverter(
             type = DoriDoriExceptionType.PLACE_FETCH_FAIL,
             message = "위치 정보가 없어요"
         )
+
+        return naverRegion.toRegion()
+    }
+
+    private fun NaverRegion.toRegion(): Region {
+        return Region(
+            국가 = when (국가) {
+                "kr" -> Nationality.KR
+                else -> Nationality.UNSUPPORTED
+            },
+            도 = 시도?.takeIf { it.endsWith("도") },
+            시 = 시도?.takeIf { it.endsWith("시") }
+                ?: 시군구?.split(" ")?.firstOrNull { it.endsWith("시") },
+            군구 = 시군구?.split(" ")?.firstOrNull { it.endsWith("군") || it.endsWith("구") },
+            읍면동 = 읍면동,
+            리 = 리,
+        )
     }
 }
+
+data class NaverRegion(
+    val 국가: String?,
+    val 시도: String?,
+    val 시군구: String?,
+    val 읍면동: String?,
+    val 리: String?,
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
@@ -1,0 +1,35 @@
+package kr.mashup.bangwidae.asked.service.place
+
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import kr.mashup.bangwidae.asked.external.map.NaverMapClient
+import org.springframework.stereotype.Component
+
+@Component
+class NaverReverseGeocodeConverter(
+    private val naverMapClient: NaverMapClient,
+) : ReverseGeocodeConverter {
+    override fun convert(longitude: Double, latitude: Double): Region {
+        val reverseGeocodeResults = naverMapClient.reverseGeocode(
+            longitude = longitude,
+            latitude = latitude,
+        )
+
+        return reverseGeocodeResults
+            .takeIf { it.isNotEmpty() }
+            ?.first()
+            ?.region
+            ?.let {
+                Region(
+                    국가 = it.area0?.name,
+                    시도 = it.area1?.name,
+                    시군구 = it.area2?.name,
+                    읍면동 = it.area3?.name,
+                    리 = it.area4?.name
+                )
+            } ?: throw DoriDoriException.of(
+            type = DoriDoriExceptionType.PLACE_FETCH_FAIL,
+            message = "위치 정보가 없어요"
+        )
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/NaverReverseGeoCodeConverter.kt
@@ -44,8 +44,8 @@ class NaverReverseGeocodeConverter(
             시 = 시도?.takeIf { it.endsWith("시") }
                 ?: 시군구?.split(" ")?.firstOrNull { it.endsWith("시") },
             군구 = 시군구?.split(" ")?.firstOrNull { it.endsWith("군") || it.endsWith("구") },
-            읍면동 = 읍면동,
-            리 = 리,
+            읍면동 = 읍면동?.takeIf { it.isNotBlank() },
+            리 = 리?.takeIf { it.isNotBlank() },
         )
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
@@ -1,0 +1,23 @@
+package kr.mashup.bangwidae.asked.service.place
+
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import org.springframework.stereotype.Service
+
+@Service
+class PlaceService(
+    private val naverReverseGeocodeConverter: NaverReverseGeocodeConverter
+) {
+    fun reverseGeocode(longitude: Double, latitude: Double): Region {
+        val region = naverReverseGeocodeConverter.convert(
+            longitude = longitude,
+            latitude = latitude,
+        )
+
+        if (region.국가 != "kr") {
+            throw DoriDoriException.of(DoriDoriExceptionType.INVALID_COUNTRY)
+        }
+
+        return region
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
@@ -14,10 +14,16 @@ class PlaceService(
             latitude = latitude,
         )
 
-        if (region.국가 != "kr") {
+        if (region.국가 === Nationality.UNSUPPORTED) {
             throw DoriDoriException.of(DoriDoriExceptionType.INVALID_COUNTRY)
         }
 
         return region
     }
+}
+
+enum class Nationality {
+    KR,
+    UNSUPPORTED,
+    ;
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/ReverseGeocodeConverter.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/ReverseGeocodeConverter.kt
@@ -1,0 +1,22 @@
+package kr.mashup.bangwidae.asked.service.place
+
+interface ReverseGeocodeConverter {
+    fun convert(longitude: Double, latitude: Double): Region
+}
+
+data class Region(
+    val 국가: String?,
+    val 시도: String?,
+    val 시군구: String?,
+    val 읍면동: String?,
+    val 리: String?,
+)
+
+data class RegionDetail(
+    val 국가: String?,
+    val 도: String?,
+    val 시: String?,
+    val 군구: String?,
+    val 읍면동: String?,
+    val 리: String?,
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/ReverseGeocodeConverter.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/ReverseGeocodeConverter.kt
@@ -5,15 +5,7 @@ interface ReverseGeocodeConverter {
 }
 
 data class Region(
-    val 국가: String?,
-    val 시도: String?,
-    val 시군구: String?,
-    val 읍면동: String?,
-    val 리: String?,
-)
-
-data class RegionDetail(
-    val 국가: String?,
+    val 국가: Nationality?,
     val 도: String?,
     val 시: String?,
     val 군구: String?,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,10 @@ server:
 jwt:
   token-issuer: bangwidae
   secret-key: secret-key # 나중에 바꿉시당
+
+map:
+  naver:
+    authorization:
+      client-id: ENC(U1ooxWX24YYjijvwLYvZxHvQ0G00KArWb4BHsPZDYE+m0WtlOVwBKtp0ik0KVKmi)
+      client-secret: ENC(ivUwyuZ35N+Du6QSg4/FMxAKdF24PavN75isNr5B696kDTA0sIKf+J0jmaSRRFvp56K42BhunyUNfDqv7iSsjsIC2CgqSGgVSPCbeKxKSlY=)
+    host: https://naveropenapi.apigw.ntruss.com


### PR DESCRIPTION
## 설명
- 위경도를 주소 정보로 변환합니다.
- 이번 PR에 포함되지 않은 부분
  - Naver Reverse Geocode API에서 에러 반환 시 예외 처리
  - 응답 DTO 정의 (기획적으로 추가 논의가 필요할 것 같아 일단 자체 정의한 Region 객체 반환)