### PR TITLE
add like

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/AnswerController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/AnswerController.kt
@@ -46,4 +46,22 @@ class AnswerController(
             ApiResponse.success(it.id!!)
         }
     }
+
+    @ApiOperation("답변 좋아요")
+    @PostMapping("/{id}/like")
+    fun likeAnswer(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        answerService.answerLike(id, user.id!!)
+        return ApiResponse.success(true)
+    }
+
+    @ApiOperation("답변 좋아요 취소")
+    @DeleteMapping("/{id}/like")
+    fun unlikeComment(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        answerService.answerUnlike(id, user.id!!)
+        return ApiResponse.success(true)
+    }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
@@ -48,4 +48,22 @@ class CommentController(
             ApiResponse.success(CommentDto.from(user, it))
         }
     }
+
+    @ApiOperation("댓글 좋아요")
+    @PostMapping("/{id}/like")
+    fun likeComment(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        commentService.commentLike(id, user.id!!)
+        return ApiResponse.success(true)
+    }
+
+    @ApiOperation("댓글 좋아요 취소")
+    @DeleteMapping("/{id}/like")
+    fun unlikeComment(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        commentService.commentUnlike(id, user.id!!)
+        return ApiResponse.success(true)
+    }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
@@ -3,8 +3,6 @@ package kr.mashup.bangwidae.asked.controller
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.*
-import kr.mashup.bangwidae.asked.exception.DoriDoriException
-import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.service.post.CommentService
 import kr.mashup.bangwidae.asked.service.post.PostService
@@ -52,10 +50,8 @@ class PostController(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
         val post = postService.findById(id)
-        return postService.delete(user, post)
-            .let {
-                ApiResponse.success(true)
-            }
+        postService.delete(user, post)
+        return ApiResponse.success(true)
     }
 
     @ApiOperation("포스트 글 좋아요")
@@ -63,11 +59,17 @@ class PostController(
     fun likePost(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        require(postService.existsById(id)) { throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST) }
-        return postService.postLike(id, user.id!!)
-            .let {
-                ApiResponse.success(true)
-            }
+        postService.postLike(id, user.id!!)
+        return ApiResponse.success(true)
+    }
+
+    @ApiOperation("포스트 글 좋아요 취소")
+    @DeleteMapping("/{id}/like")
+    fun unlikePost(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        postService.postUnlike(id, user.id!!)
+        return ApiResponse.success(true)
     }
 
     @ApiOperation("거리 반경 포스트 글 페이징")

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
@@ -3,6 +3,8 @@ package kr.mashup.bangwidae.asked.controller
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.*
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.service.post.CommentService
 import kr.mashup.bangwidae.asked.service.post.PostService
@@ -51,6 +53,18 @@ class PostController(
     ): ApiResponse<Boolean> {
         val post = postService.findById(id)
         return postService.delete(user, post)
+            .let {
+                ApiResponse.success(true)
+            }
+    }
+
+    @ApiOperation("포스트 글 좋아요")
+    @PostMapping("/{id}/like")
+    fun likePost(
+        @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
+    ): ApiResponse<Boolean> {
+        require(postService.existsById(id)) { throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST) }
+        return postService.postLike(id, user.id!!)
             .let {
                 ApiResponse.success(true)
             }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/CommentLike.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/CommentLike.kt
@@ -1,0 +1,13 @@
+package kr.mashup.bangwidae.asked.model.post
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("comment-like")
+data class CommentLike(
+    @Id
+    val id: ObjectId? = null,
+    val userId: ObjectId,
+    val commentId: ObjectId
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/PostLike.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/PostLike.kt
@@ -1,0 +1,13 @@
+package kr.mashup.bangwidae.asked.model.post
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("post-like")
+data class PostLike(
+    @Id
+    val id: ObjectId? = null,
+    val userId: ObjectId,
+    val postId: ObjectId
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/question/AnswerLike.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/question/AnswerLike.kt
@@ -1,0 +1,13 @@
+package kr.mashup.bangwidae.asked.model.question
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("answer-like")
+data class AnswerLike(
+    @Id
+    val id: ObjectId? = null,
+    val userId: ObjectId,
+    val answerId: ObjectId
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeRepository.kt
@@ -1,0 +1,10 @@
+package kr.mashup.bangwidae.asked.repository
+
+import kr.mashup.bangwidae.asked.model.question.AnswerLike
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AnswerLikeRepository : MongoRepository<AnswerLike, ObjectId> {
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface AnswerLikeRepository : MongoRepository<AnswerLike, ObjectId> {
+    fun existsByAnswerIdAndUserId(answerId: ObjectId, userId: ObjectId): Boolean
+    fun findByAnswerIdAndUserId(answerId: ObjectId, userId: ObjectId): AnswerLike?
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface AnswerRepository : MongoRepository<Answer, ObjectId> {
     fun findByIdAndDeletedFalse(id: ObjectId): Answer?
-
+    fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun countByQuestionIdAndDeletedFalse(questionId: ObjectId): Long
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface CommentLikeRepository : MongoRepository<CommentLike, ObjectId> {
+    fun existsByCommentIdAndUserId(commentId: ObjectId, userId: ObjectId): Boolean
+    fun findByCommentIdAndUserId(commentId: ObjectId, userId: ObjectId): CommentLike?
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
@@ -1,0 +1,10 @@
+package kr.mashup.bangwidae.asked.repository
+
+import kr.mashup.bangwidae.asked.model.post.CommentLike
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CommentLikeRepository : MongoRepository<CommentLike, ObjectId> {
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentRepository.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository
 interface CommentRepository : MongoRepository<Comment, ObjectId> {
     fun findByIdAndDeletedFalse(id: ObjectId): Comment?
     fun existsByPostIdAndIdBeforeAndDeletedFalse(postId: ObjectId, lastId: ObjectId): Boolean
-
+    fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun findByPostIdAndIdBeforeAndDeletedFalseOrderByIdDesc(
         postId: ObjectId,
         lastId: ObjectId,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface PostLikeRepository : MongoRepository<PostLike, ObjectId> {
+    fun existsByPostIdAndUserId(postId: ObjectId, userId: ObjectId): Boolean
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
@@ -1,0 +1,10 @@
+package kr.mashup.bangwidae.asked.repository
+
+import kr.mashup.bangwidae.asked.model.post.PostLike
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PostLikeRepository : MongoRepository<PostLike, ObjectId> {
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface PostLikeRepository : MongoRepository<PostLike, ObjectId> {
     fun existsByPostIdAndUserId(postId: ObjectId, userId: ObjectId): Boolean
+    fun findByPostIdAndUserId(postId: ObjectId, userId: ObjectId): PostLike?
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostRepository.kt
@@ -17,6 +17,7 @@ interface PostRepository : MongoRepository<Post, ObjectId> {
         pageRequest: PageRequest
     ): List<Post>
 
+    fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun findByIdAndDeletedFalse(id: ObjectId): Post?
     fun findByLocationNear(location: GeoJsonPoint, distance: Distance): List<Post>
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
@@ -6,7 +6,9 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Comment
+import kr.mashup.bangwidae.asked.model.post.CommentLike
 import kr.mashup.bangwidae.asked.model.post.Post
+import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
 import kr.mashup.bangwidae.asked.repository.CommentRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
 import kr.mashup.bangwidae.asked.service.place.PlaceService
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
+    private val commentLikeRepository: CommentLikeRepository,
     private val userRepository: UserRepository,
     private val placeService: PlaceService
 ) : WithPostAuthorityValidator, WithCommentAuthorityValidator {
@@ -57,6 +60,21 @@ class CommentService(
     fun delete(user: User, comment: Comment): Comment {
         comment.validateToDelete(user)
         return commentRepository.save(comment.delete())
+    }
+
+    fun commentLike(commentId: ObjectId, userId: ObjectId) {
+        require(commentRepository.existsByIdAndDeletedFalse(commentId)) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+        }
+        if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
+            commentLikeRepository.save(CommentLike(userId = userId, commentId = commentId))
+        }
+    }
+
+    fun commentUnlike(commentId: ObjectId, userId: ObjectId) {
+        commentLikeRepository.findByCommentIdAndUserId(commentId, userId)?.let {
+            commentLikeRepository.delete(it)
+        }
     }
 
     private fun hasNext(postId: ObjectId, id: ObjectId?): Boolean {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -78,7 +78,9 @@ class PostService(
     }
 
     fun postLike(postId: ObjectId, userId: ObjectId) {
-        postLikeRepository.save(PostLike(userId = userId, postId = postId))
+        if (!postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+            postLikeRepository.save(PostLike(userId = userId, postId = postId))
+        }
     }
 
     private fun hasNext(location: GeoJsonPoint, id: ObjectId?, distance: Distance): Boolean {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -6,6 +6,8 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Post
+import kr.mashup.bangwidae.asked.model.post.PostLike
+import kr.mashup.bangwidae.asked.repository.PostLikeRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
 import kr.mashup.bangwidae.asked.service.place.PlaceService
@@ -24,11 +26,16 @@ import org.springframework.stereotype.Service
 class PostService(
     private val postRepository: PostRepository,
     private val placeService: PlaceService,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val postLikeRepository: PostLikeRepository
 ) : WithPostAuthorityValidator {
     fun findById(id: ObjectId): Post {
         return postRepository.findByIdAndDeletedFalse(id)
             ?: throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+    }
+
+    fun existsById(id: ObjectId): Boolean {
+        return postRepository.existsByIdAndDeletedFalse(id)
     }
 
     fun write(post: Post): Post {
@@ -68,6 +75,10 @@ class PostService(
         val user = userRepository.findByIdOrNull(post.userId)
             ?: throw DoriDoriException.of(DoriDoriExceptionType.POST_WRITER_USER_NOT_EXIST)
         return PostDto.from(user, post)
+    }
+
+    fun postLike(postId: ObjectId, userId: ObjectId) {
+        postLikeRepository.save(PostLike(userId = userId, postId = postId))
     }
 
     private fun hasNext(location: GeoJsonPoint, id: ObjectId?, distance: Distance): Boolean {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -34,10 +34,6 @@ class PostService(
             ?: throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
     }
 
-    fun existsById(id: ObjectId): Boolean {
-        return postRepository.existsByIdAndDeletedFalse(id)
-    }
-
     fun write(post: Post): Post {
         return postRepository.save(updatePlaceInfo(post))
     }
@@ -78,8 +74,17 @@ class PostService(
     }
 
     fun postLike(postId: ObjectId, userId: ObjectId) {
+        require(postRepository.existsByIdAndDeletedFalse(postId)) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+        }
         if (!postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
             postLikeRepository.save(PostLike(userId = userId, postId = postId))
+        }
+    }
+
+    fun postUnlike(postId: ObjectId, userId: ObjectId) {
+        postLikeRepository.findByPostIdAndUserId(postId, userId)?.let {
+            postLikeRepository.delete(it)
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
@@ -6,6 +6,8 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.question.Answer
+import kr.mashup.bangwidae.asked.model.question.AnswerLike
+import kr.mashup.bangwidae.asked.repository.AnswerLikeRepository
 import kr.mashup.bangwidae.asked.repository.AnswerRepository
 import kr.mashup.bangwidae.asked.repository.QuestionRepository
 import org.bson.types.ObjectId
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AnswerService(
     private val answerRepository: AnswerRepository,
+    private val answerLikeRepository: AnswerLikeRepository,
     private val questionRepository: QuestionRepository,
 ) : WithQuestionAuthorityValidator, WithAnswerAuthorityValidator {
     fun findById(answerId: ObjectId): Answer {
@@ -61,6 +64,21 @@ class AnswerService(
             if (answerDoesNotExist(it.questionId)) {
                 makeQuestionWaiting(it.questionId)
             }
+        }
+    }
+
+    fun answerLike(answerId: ObjectId, userId: ObjectId) {
+        require(answerRepository.existsByIdAndDeletedFalse(answerId)) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+        }
+        if (!answerLikeRepository.existsByAnswerIdAndUserId(answerId, userId)) {
+            answerLikeRepository.save(AnswerLike(userId = userId, answerId = answerId))
+        }
+    }
+
+    fun answerUnlike(answerId: ObjectId, userId: ObjectId) {
+        answerLikeRepository.findByAnswerIdAndUserId(answerId, userId)?.let {
+            answerLikeRepository.delete(it)
         }
     }
 


### PR DESCRIPTION
#68 
샘플로 한번 만들어봤는데 검토 부탁드려용~
그냥 Like로 만들고 type(comment, post, answer) 로 관리할까도 했는데 하나로 굳이 할 이유는 없는거같아서 그냥 각각 PostLike, CommentLike, AnswerLike로 분리했어용

1) 저장되는 필드: id, userId, xxId.
2) 제외되는 필드: createdDate, modifiedDate, version, deleted 등... 
- 업데이트 없이 이거 그냥 좋아요 누르면 저장하고 unlike api 호출하면 하드 딜리트 시킬거라 저런 관리용 필드 제외함
3) 동작
- like: postId, userId로 조회에서 없으면 저장. 있으면 무시
- unlike: postId, userId로 조회해서 하드 딜리트(삭제)