### PR TITLE
미답변 질문 개수 기반 Header Text API

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.*
 import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.service.HeaderTextType
 import kr.mashup.bangwidae.asked.service.UserService
 import kr.mashup.bangwidae.asked.service.question.QuestionService
 import org.bson.types.ObjectId
@@ -82,8 +83,9 @@ class UserController(
     @GetMapping("/header-text")
     fun getHeaderText(
         @ApiIgnore @AuthenticationPrincipal user: User,
+        @RequestParam type: HeaderTextType,
     ): ApiResponse<String> {
-        return ApiResponse.success("헤더 텍스트 예시")
+        return ApiResponse.success(userService.getUserHeaderText(user, type))
     }
 
     @ApiOperation("답변완료(본인)")

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/QuestionRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/QuestionRepository.kt
@@ -18,6 +18,11 @@ interface QuestionRepository : MongoRepository<Question, ObjectId> {
         pageRequest: PageRequest,
     ): List<Question>
 
+    fun countByToUserIdAndStatusAndDeletedFalse(
+        toUserId: ObjectId,
+        status: QuestionStatus,
+    ): Long
+
     fun findByFromUserIdAndIdBeforeAndDeletedFalseOrderByCreatedAtDesc(
         fromUserId: ObjectId,
         lastId: ObjectId,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -9,6 +9,7 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.external.aws.S3ImageUploader
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.repository.UserRepository
+import kr.mashup.bangwidae.asked.service.question.QuestionService
 import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -20,6 +21,7 @@ class UserService(
     private val userRepository: UserRepository,
     private val certMailService: CertMailService,
     private val passwordService: PasswordService,
+    private val questionService: QuestionService,
     private val s3ImageUploader: S3ImageUploader
 ) {
 
@@ -52,6 +54,16 @@ class UserService(
     fun getUserInfo(userId: ObjectId): User {
         return userRepository.findById(userId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+    }
+
+    fun getUserHeaderText(user: User, type: HeaderTextType): String {
+        return when (type) {
+            HeaderTextType.ANSWER_WAITING_QUESTION_COUNT
+            -> "답변을 기다리는 질문이 ${questionService.countAnswerWaitingByToUser(user)}개 있어요"
+            // TODO 미확인 질문 카운트
+            HeaderTextType.UNREAD_QUESTION_COUNT
+            -> "새로운 질문이 n개 도착했어요"
+        }
     }
 
     fun updateNickname(user: User, nickname: String): Boolean {
@@ -96,4 +108,9 @@ class UserService(
             throw DoriDoriException.of(DoriDoriExceptionType.DUPLICATED_NICKNAME)
         }
     }
+}
+
+enum class HeaderTextType {
+    UNREAD_QUESTION_COUNT,
+    ANSWER_WAITING_QUESTION_COUNT,
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -49,6 +49,13 @@ class QuestionService(
         )
     }
 
+    fun countAnswerWaitingByToUser(user: User): Long {
+        return questionRepository.countByToUserIdAndStatusAndDeletedFalse(
+            toUserId = user.id!!,
+            status = QuestionStatus.ANSWER_WAITING,
+        )
+    }
+
     fun findAnswerCompleteByToUser(userId: ObjectId, lastId: ObjectId?, size: Int): QuestionSearchResultWithAnswerImpl {
         val user = userRepository.findByIdOrNull(userId)
             ?: throw DoriDoriException.of(


### PR DESCRIPTION
#85 

답변 대기(ANSWER_WAITING) 상태의 Question 개수를 기반으로 Header Text를 반환하는 API

기획은 미확인 Question 이지만,, 추가 구현(Question 읽음 처리 API 등)이 필요해 일단 현재 가능한 스펙으로 선개발 했습니다.