### PR TITLE
Feature/70 Post, Comment에 댓글개수, 좋아요 개수, 사용자가 좋아요한 여부 넣어주기

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
@@ -3,9 +3,10 @@ package kr.mashup.bangwidae.asked.controller
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.ApiResponse
-import kr.mashup.bangwidae.asked.controller.dto.CommentDto
+import kr.mashup.bangwidae.asked.controller.dto.CommentResultDto
 import kr.mashup.bangwidae.asked.controller.dto.CommentEditRequest
 import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.service.post.CommentLikeService
 import kr.mashup.bangwidae.asked.service.post.CommentService
 import org.bson.types.ObjectId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -16,7 +17,8 @@ import springfox.documentation.annotations.ApiIgnore
 @RestController
 @RequestMapping("/api/v1/comments")
 class CommentController(
-    private val commentService: CommentService
+    private val commentService: CommentService,
+    private val commentLikeService: CommentLikeService
 ) {
     @ApiOperation("댓글 수정")
     @PatchMapping("/{commentId}")
@@ -24,13 +26,13 @@ class CommentController(
         @ApiIgnore @AuthenticationPrincipal user: User,
         @PathVariable commentId: ObjectId,
         @RequestBody commentEditRequest: CommentEditRequest,
-    ): ApiResponse<CommentDto> {
+    ): ApiResponse<CommentResultDto> {
         return commentService.edit(
             commentId = commentId,
             user = user,
             request = commentEditRequest
         ).let {
-            ApiResponse.success(CommentDto.from(user, it))
+            ApiResponse.success(CommentResultDto.from(user, it))
         }
     }
 
@@ -39,12 +41,12 @@ class CommentController(
     fun deleteAnswer(
         @ApiIgnore @AuthenticationPrincipal user: User,
         @PathVariable commentId: ObjectId,
-    ): ApiResponse<CommentDto> {
+    ): ApiResponse<CommentResultDto> {
         return commentService.delete(
             commentId = commentId,
             user = user,
         ).let {
-            ApiResponse.success(CommentDto.from(user, it))
+            ApiResponse.success(CommentResultDto.from(user, it))
         }
     }
 
@@ -53,7 +55,7 @@ class CommentController(
     fun likeComment(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        commentService.commentLike(id, user.id!!)
+        commentLikeService.commentLike(id, user.id!!)
         return ApiResponse.success(true)
     }
 
@@ -62,7 +64,7 @@ class CommentController(
     fun unlikeComment(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        commentService.commentUnlike(id, user.id!!)
+        commentLikeService.commentUnlike(id, user.id!!)
         return ApiResponse.success(true)
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
@@ -27,7 +27,8 @@ class CommentController(
     ): ApiResponse<CommentDto> {
         return commentService.edit(
             commentId = commentId,
-            user = user
+            user = user,
+            request = commentEditRequest
         ).let {
             ApiResponse.success(CommentDto.from(user, it))
         }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
@@ -109,13 +109,13 @@ class PostController(
         @ApiIgnore @AuthenticationPrincipal user: User,
         @PathVariable postId: ObjectId,
         @RequestBody commentWriteRequest: CommentWriteRequest,
-    ): ApiResponse<CommentDto> {
+    ): ApiResponse<CommentResultDto> {
         return commentService.write(
             user = user,
             postId = postId,
             comment = commentWriteRequest.toEntity(user.id!!, postId)
         ).let {
-            ApiResponse.success(CommentDto.from(user, it))
+            ApiResponse.success(CommentResultDto.from(user, it))
         }
     }
 
@@ -127,7 +127,7 @@ class PostController(
         @RequestParam size: Int,
         @RequestParam(required = false) lastId: ObjectId?
     ): ApiResponse<CursorResult<CommentDto>> {
-        return commentService.getCommentsByPostId(postId, lastId, size + 1)
+        return commentService.getCommentsByPostId(user.id!!, postId, lastId, size + 1)
             .let {
                 ApiResponse.success(CursorResult.from(values = it, requestedSize = size))
             }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.*
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.service.post.CommentService
+import kr.mashup.bangwidae.asked.service.post.PostLikeService
 import kr.mashup.bangwidae.asked.service.post.PostService
 import org.bson.types.ObjectId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -16,17 +17,18 @@ import springfox.documentation.annotations.ApiIgnore
 @RequestMapping("/api/v1/posts")
 class PostController(
     private val postService: PostService,
+    private val postLikeService: PostLikeService,
     private val commentService: CommentService
 ) {
     @ApiOperation("포스트 글 작성")
     @PostMapping
     fun writePost(
         @ApiIgnore @AuthenticationPrincipal user: User, @RequestBody postWriteRequest: PostWriteRequest
-    ): ApiResponse<PostDto> {
+    ): ApiResponse<PostResultDto> {
         val post = postWriteRequest.toEntity(user.id!!)
         return postService.write(post)
             .let {
-                ApiResponse.success(PostDto.from(user, it))
+                ApiResponse.success(PostResultDto.from(user, it))
             }
     }
 
@@ -36,13 +38,13 @@ class PostController(
         @ApiIgnore @AuthenticationPrincipal user: User,
         @RequestBody postEditRequest: PostEditRequest,
         @PathVariable id: ObjectId
-    ): ApiResponse<PostDto> {
+    ): ApiResponse<PostResultDto> {
         return postService.edit(
             postId = id,
             user = user,
             request = postEditRequest
         ).let {
-            ApiResponse.success(PostDto.from(user, it))
+            ApiResponse.success(PostResultDto.from(user, it))
         }
     }
 
@@ -60,7 +62,7 @@ class PostController(
     fun likePost(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        postService.postLike(id, user.id!!)
+        postLikeService.postLike(id, user.id!!)
         return ApiResponse.success(true)
     }
 
@@ -69,20 +71,21 @@ class PostController(
     fun unlikePost(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        postService.postUnlike(id, user.id!!)
+        postLikeService.postUnlike(id, user.id!!)
         return ApiResponse.success(true)
     }
 
     @ApiOperation("거리 반경 포스트 글 페이징")
     @GetMapping("/near")
     fun getNearPosts(
+        @ApiIgnore @AuthenticationPrincipal user: User,
         @RequestParam longitude: Double,
         @RequestParam latitude: Double,
         @RequestParam meterDistance: Double,
         @RequestParam size: Int,
         @RequestParam(required = false) lastId: ObjectId?
     ): ApiResponse<CursorResult<PostDto>> {
-        return postService.getNearPost(longitude, latitude, meterDistance, lastId, size + 1)
+        return postService.getNearPost(user.id!!, longitude, latitude, meterDistance, lastId, size + 1)
             .let {
                 ApiResponse.success(CursorResult.from(values = it, requestedSize = size))
             }
@@ -91,9 +94,10 @@ class PostController(
     @ApiOperation("포스트 글 조회")
     @GetMapping("/{id}")
     fun getPostById(
+        @ApiIgnore @AuthenticationPrincipal user: User,
         @PathVariable id: ObjectId
     ): ApiResponse<PostDto> {
-        return postService.getPostById(id)
+        return postService.getPostById(user.id!!, id)
             .let {
                 ApiResponse.success(it)
             }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -10,7 +10,9 @@ import java.time.LocalDateTime
 data class CommentWriteRequest(
     @ApiModelProperty(value = "댓글 내용", example = "댓글 내용 string")
     val content: String,
+    @ApiModelProperty(value = "경도", example = "136.4")
     val longitude: Double,
+    @ApiModelProperty(value = "위도", example = "36.4")
     val latitude: Double
 ) {
     fun toEntity(userId: ObjectId, postId: ObjectId): Comment {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentResultDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentResultDto.kt
@@ -39,6 +39,10 @@ data class CommentDto(
     val user: CommentWriter,
     @ApiModelProperty(value = "댓글 내용", example = "댓글 내용 string")
     val content: String,
+    @ApiModelProperty(value = "좋아요 개수", example = "10")
+    val likeCount: Int,
+    @ApiModelProperty(value = "사용자가 좋아요 누른 여부", example = "true")
+    val userLiked: Boolean,
     @ApiModelProperty(value = "대표 주소", example = "분당구")
     val representativeAddress: String?,
     @ApiModelProperty(value = "생성일", example = "2022-07-14T23:57:33.436")
@@ -47,8 +51,42 @@ data class CommentDto(
     val updatedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(user: User, comment: Comment): CommentDto {
+        fun from(user: User, comment: Comment, likeCount: Int, userLiked: Boolean): CommentDto {
             return CommentDto(
+                id = comment.id!!.toHexString(),
+                user = CommentWriter(
+                    id = user.id!!.toHexString(),
+                    tags = user.tags,
+                    nickname = user.nickname!!
+                ),
+                content = comment.content,
+                likeCount = likeCount,
+                userLiked = userLiked,
+                representativeAddress = comment.region?.representativeAddress,
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt
+            )
+        }
+    }
+}
+
+data class CommentResultDto(
+    @ApiModelProperty(value = "댓글 id", example = "62c6f1ede8802854c463b5f5")
+    val id: String,
+    @ApiModelProperty(value = "댓글 작성자 User")
+    val user: CommentWriter,
+    @ApiModelProperty(value = "댓글 내용", example = "댓글 내용 string")
+    val content: String,
+    @ApiModelProperty(value = "대표 주소", example = "분당구")
+    val representativeAddress: String?,
+    @ApiModelProperty(value = "생성일", example = "2022-07-14T23:57:33.436")
+    val createdAt: LocalDateTime?,
+    @ApiModelProperty(value = "수정일", example = "2022-07-14T23:57:33.436")
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(user: User, comment: Comment): CommentResultDto {
+            return CommentResultDto(
                 id = comment.id!!.toHexString(),
                 user = CommentWriter(
                     id = user.id!!.toHexString(),

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
@@ -10,13 +10,21 @@ import org.bson.types.ObjectId
 import java.time.LocalDateTime
 
 data class PostDto(
+    @ApiModelProperty(value = "포스트 글 id", example = "62d81cd92336cf4bb5b6c6ab")
     val id: String,
+    @ApiModelProperty(value = "포스트 글 작성자", example = "")
     val user: PostWriter,
+    @ApiModelProperty(value = "포스트 글 내용", example = "글")
     val content: String = "",
+    @ApiModelProperty(value = "경도", example = "136.4")
     val longitude: Double,
+    @ApiModelProperty(value = "위도", example = "36.4")
     val latitude: Double,
+    @ApiModelProperty(value = "대표주소", example = "강남구")
     val representativeAddress: String?,
+    @ApiModelProperty(value = "생성일", example = "2022-07-14T23:57:33.436")
     val createdAt: LocalDateTime?,
+    @ApiModelProperty(value = "수정일", example = "2022-07-14T23:57:33.436")
     val updatedAt: LocalDateTime?
 ) {
     companion object {
@@ -60,7 +68,10 @@ data class PostEditRequest(
 )
 
 data class PostWriter(
+    @ApiModelProperty(value = "글 작성자 id", example = "62d81cd92336cf4bb5b6c6ab")
     val id: String,
+    @ApiModelProperty(value = "글 작성자 tag list", example = "mbti, entj")
     val tags: List<String> = emptyList(),
+    @ApiModelProperty(value = "글 작성자 닉네임", example = "sample nickname")
     val nickname: String
 )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
@@ -9,7 +9,7 @@ import kr.mashup.bangwidae.asked.utils.getLongitude
 import org.bson.types.ObjectId
 import java.time.LocalDateTime
 
-data class PostDto(
+data class PostResultDto(
     @ApiModelProperty(value = "포스트 글 id", example = "62d81cd92336cf4bb5b6c6ab")
     val id: String,
     @ApiModelProperty(value = "포스트 글 작성자", example = "")
@@ -28,7 +28,57 @@ data class PostDto(
     val updatedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(user: User, post: Post): PostDto {
+        fun from(user: User, post: Post): PostResultDto {
+            return PostResultDto(
+                id = post.id!!.toHexString(),
+                user = PostWriter(
+                    id = user.id!!.toHexString(),
+                    tags = user.tags,
+                    nickname = user.nickname!!
+                ),
+                content = post.content,
+                longitude = post.location.getLongitude(),
+                latitude = post.location.getLatitude(),
+                representativeAddress = post.representativeAddress,
+                createdAt = post.createdAt,
+                updatedAt = post.updatedAt,
+            )
+        }
+    }
+}
+
+data class PostDto(
+    @ApiModelProperty(value = "포스트 글 id", example = "62d81cd92336cf4bb5b6c6ab")
+    val id: String,
+    @ApiModelProperty(value = "포스트 글 작성자", example = "")
+    val user: PostWriter,
+    @ApiModelProperty(value = "포스트 글 내용", example = "글")
+    val content: String = "",
+    @ApiModelProperty(value = "좋아요 개수", example = "10")
+    val likeCount: Int,
+    @ApiModelProperty(value = "댓글 개수", example = "10")
+    val commentCount: Int,
+    @ApiModelProperty(value = "사용자가 좋아요 누른 여부", example = "true")
+    val userLiked: Boolean,
+    @ApiModelProperty(value = "경도", example = "136.4")
+    val longitude: Double,
+    @ApiModelProperty(value = "위도", example = "36.4")
+    val latitude: Double,
+    @ApiModelProperty(value = "대표주소", example = "강남구")
+    val representativeAddress: String?,
+    @ApiModelProperty(value = "생성일", example = "2022-07-14T23:57:33.436")
+    val createdAt: LocalDateTime?,
+    @ApiModelProperty(value = "수정일", example = "2022-07-14T23:57:33.436")
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(
+            user: User,
+            post: Post,
+            likeCount: Int,
+            commentCount: Int,
+            userLiked: Boolean
+        ): PostDto {
             return PostDto(
                 id = post.id!!.toHexString(),
                 user = PostWriter(
@@ -37,6 +87,9 @@ data class PostDto(
                     nickname = user.nickname!!
                 ),
                 content = post.content,
+                likeCount = likeCount,
+                userLiked = userLiked,
+                commentCount = commentCount,
                 longitude = post.location.getLongitude(),
                 latitude = post.location.getLatitude(),
                 representativeAddress = post.representativeAddress,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentLikeRepository.kt
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository
 interface CommentLikeRepository : MongoRepository<CommentLike, ObjectId> {
     fun existsByCommentIdAndUserId(commentId: ObjectId, userId: ObjectId): Boolean
     fun findByCommentIdAndUserId(commentId: ObjectId, userId: ObjectId): CommentLike?
+    fun findAllByCommentIdIn(commentIdList: List<ObjectId>): List<CommentLike>
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/CommentRepository.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CommentRepository : MongoRepository<Comment, ObjectId> {
     fun findByIdAndDeletedFalse(id: ObjectId): Comment?
-    fun existsByPostIdAndIdBeforeAndDeletedFalse(postId: ObjectId, lastId: ObjectId): Boolean
+    fun findAllByPostIdIn(postIdList: List<ObjectId>): List<Comment>
     fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun findByPostIdAndIdBeforeAndDeletedFalseOrderByIdDesc(
         postId: ObjectId,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/PostLikeRepository.kt
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository
 interface PostLikeRepository : MongoRepository<PostLike, ObjectId> {
     fun existsByPostIdAndUserId(postId: ObjectId, userId: ObjectId): Boolean
     fun findByPostIdAndUserId(postId: ObjectId, userId: ObjectId): PostLike?
+    fun findAllByPostIdIn(postIdList: List<ObjectId>): List<PostLike>
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
@@ -1,0 +1,36 @@
+package kr.mashup.bangwidae.asked.service.post
+
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import kr.mashup.bangwidae.asked.model.post.Comment
+import kr.mashup.bangwidae.asked.model.post.CommentLike
+import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
+import kr.mashup.bangwidae.asked.repository.CommentRepository
+import org.bson.types.ObjectId
+import org.springframework.stereotype.Service
+
+@Service
+class CommentLikeService(
+    private val commentLikeRepository: CommentLikeRepository,
+    private val commentRepository: CommentRepository
+) {
+    fun commentLike(commentId: ObjectId, userId: ObjectId) {
+        require(commentRepository.existsByIdAndDeletedFalse(commentId)) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+        }
+        if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
+            commentLikeRepository.save(CommentLike(userId = userId, commentId = commentId))
+        }
+    }
+
+    fun commentUnlike(commentId: ObjectId, userId: ObjectId) {
+        commentLikeRepository.findByCommentIdAndUserId(commentId, userId)?.let {
+            commentLikeRepository.delete(it)
+        }
+    }
+
+    fun getLikeMap(commentList: List<Comment>): Map<ObjectId, List<CommentLike>> {
+        val commentLikeList = commentLikeRepository.findAllByCommentIdIn(commentList.mapNotNull { it.id })
+        return commentLikeList.groupBy { it.commentId }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
@@ -1,6 +1,7 @@
 package kr.mashup.bangwidae.asked.service.post
 
 import kr.mashup.bangwidae.asked.controller.dto.CommentDto
+import kr.mashup.bangwidae.asked.controller.dto.CommentEditRequest
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
@@ -51,9 +52,9 @@ class CommentService(
         return commentRepository.save(updatePlaceInfo(comment))
     }
 
-    fun edit(user: User, commentId: ObjectId): Comment {
+    fun edit(user: User, commentId: ObjectId, request: CommentEditRequest): Comment {
         val comment = findById(commentId).also { it.validateToUpdate(user) }
-        return commentRepository.save(updatePlaceInfo(comment))
+        return commentRepository.save(updatePlaceInfo(comment.update(request)))
     }
 
     fun delete(user: User, commentId: ObjectId): Comment {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
@@ -6,9 +6,7 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Comment
-import kr.mashup.bangwidae.asked.model.post.CommentLike
 import kr.mashup.bangwidae.asked.model.post.Post
-import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
 import kr.mashup.bangwidae.asked.repository.CommentRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
@@ -23,10 +21,10 @@ import org.springframework.stereotype.Service
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
-    private val commentLikeRepository: CommentLikeRepository,
     private val postRepository: PostRepository,
     private val userRepository: UserRepository,
-    private val placeService: PlaceService
+    private val placeService: PlaceService,
+    private val commentLikeService: CommentLikeService
 ) : WithPostAuthorityValidator, WithCommentAuthorityValidator {
     fun findById(commentId: ObjectId): Comment {
         return commentRepository.findByIdAndDeletedFalse(commentId)
@@ -34,7 +32,7 @@ class CommentService(
     }
 
     fun getCommentsByPostId(
-        postId: ObjectId, lastId: ObjectId?, size: Int
+        userId: ObjectId, postId: ObjectId, lastId: ObjectId?, size: Int
     ): List<CommentDto> {
         val commentList = commentRepository.findByPostIdAndIdBeforeAndDeletedFalseOrderByIdDesc(
             postId,
@@ -43,7 +41,15 @@ class CommentService(
         )
         val userIdList = commentList.map { it.userId }.distinct()
         val userMap = userRepository.findAllByIdIn(userIdList).associateBy { it.id }
-        return commentList.map { CommentDto.from(userMap[it.userId]!!, it) }
+        val likeMap = commentLikeService.getLikeMap(commentList)
+        return commentList.map {
+            CommentDto.from(
+                user = userMap[it.userId]!!,
+                comment = it,
+                likeCount = likeMap[it.id]?.size ?: 0,
+                userLiked = likeMap[it.id]?.map { like -> like.userId }?.contains(userId) ?: false
+            )
+        }
     }
 
     fun getCommentCountMap(postList: List<Post>): Map<ObjectId, Int> {
@@ -66,21 +72,6 @@ class CommentService(
     fun delete(user: User, commentId: ObjectId): Comment {
         val comment = findById(commentId).also { it.validateToDelete(user) }
         return commentRepository.save(comment.delete())
-    }
-
-    fun commentLike(commentId: ObjectId, userId: ObjectId) {
-        require(commentRepository.existsByIdAndDeletedFalse(commentId)) {
-            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
-        }
-        if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
-            commentLikeRepository.save(CommentLike(userId = userId, commentId = commentId))
-        }
-    }
-
-    fun commentUnlike(commentId: ObjectId, userId: ObjectId) {
-        commentLikeRepository.findByCommentIdAndUserId(commentId, userId)?.let {
-            commentLikeRepository.delete(it)
-        }
     }
 
     private fun updatePlaceInfo(comment: Comment): Comment {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
@@ -7,6 +7,7 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Comment
 import kr.mashup.bangwidae.asked.model.post.CommentLike
+import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
 import kr.mashup.bangwidae.asked.repository.CommentRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
@@ -43,6 +44,11 @@ class CommentService(
         val userIdList = commentList.map { it.userId }.distinct()
         val userMap = userRepository.findAllByIdIn(userIdList).associateBy { it.id }
         return commentList.map { CommentDto.from(userMap[it.userId]!!, it) }
+    }
+
+    fun getCommentCountMap(postList: List<Post>): Map<ObjectId, Int> {
+        val commentList = commentRepository.findAllByPostIdIn(postList.mapNotNull { it.id })
+        return commentList.groupingBy { it.postId }.eachCount()
     }
 
     fun write(user: User, postId: ObjectId, comment: Comment): Comment {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
@@ -1,0 +1,36 @@
+package kr.mashup.bangwidae.asked.service.post
+
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import kr.mashup.bangwidae.asked.model.post.Post
+import kr.mashup.bangwidae.asked.model.post.PostLike
+import kr.mashup.bangwidae.asked.repository.PostLikeRepository
+import kr.mashup.bangwidae.asked.repository.PostRepository
+import org.bson.types.ObjectId
+import org.springframework.stereotype.Service
+
+@Service
+class PostLikeService(
+    private val postLikeRepository: PostLikeRepository,
+    private val postRepository: PostRepository
+) {
+    fun postLike(postId: ObjectId, userId: ObjectId) {
+        require(postRepository.existsByIdAndDeletedFalse(postId)) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+        }
+        if (!postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+            postLikeRepository.save(PostLike(userId = userId, postId = postId))
+        }
+    }
+
+    fun postUnlike(postId: ObjectId, userId: ObjectId) {
+        postLikeRepository.findByPostIdAndUserId(postId, userId)?.let {
+            postLikeRepository.delete(it)
+        }
+    }
+
+    fun getLikeMap(postList: List<Post>): Map<ObjectId, List<PostLike>> {
+        val postLikeList = postLikeRepository.findAllByPostIdIn(postList.mapNotNull { it.id })
+        return postLikeList.groupBy { it.postId }
+    }
+}


### PR DESCRIPTION
#70 
Comment랑 Post에 댓글개수 좋아요 개수 넣어주도록 작업했습니다.
그리고 기존에 XXXDto로 퉁~ 쳐서 모든 경우에서 반환하였었는데
조회용으로만 XXXDto 남겨놓고, 단순 반환용(수정, 생성 등)일때는 XXXResultDto로 반환하도록 분리했습니다.


-> @SeongYunKim , Answer도 작업 해주려고 했는데 지금 성윤쓰 로직이 내꺼랑 좀 달라서 이거는 내가 손대면 더러워질거같은데 혹시 손대도괜찮은지 아니면 직접 내가 한거 참고해서 편한대로 추가할지 의견부탁드립니당
내가 작업할거면 QuestionSearchResultWithAnswerImpl 에다가 likeMap 추가해서 끼워넣어서 조립할 예정!