### PR TITLE
QuestionDto Refactoring & 질문, 답변 작성 시 레벨업 체크

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -47,10 +47,7 @@ class SecurityConfig {
                 "/api/v1/place/reverse/geocode",
                 "/api/v1/auth/mail/send",
                 "/api/v1/auth/mail/cert",
-
-                // 테스트를 위해 임시로 허용
-                "/api/v1/user/answered-questions",
-                "/api/v1/user/received-questions",
+                "/api/v1/questions/{questionId}",
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -18,7 +18,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter
 
 
@@ -48,6 +47,7 @@ class SecurityConfig {
                 "/api/v1/auth/mail/send",
                 "/api/v1/auth/mail/cert",
                 "/api/v1/questions/{questionId}",
+                "/api/v1/questions/answered",
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig {
                 "/api/v1/auth/mail/cert",
                 "/api/v1/questions/{questionId}",
                 "/api/v1/questions/answered",
+                "/api/v1/user/{userId}/link-share"
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
@@ -25,7 +25,7 @@ class QuestionController(
         @PathVariable questionId: ObjectId,
     ): ApiResponse<QuestionDetailDto> {
         return questionService.findDetailById(
-            user = user,
+            authUser = user,
             questionId = questionId,
         ).let {
             ApiResponse.success(
@@ -37,12 +37,14 @@ class QuestionController(
     @ApiOperation("답변완료(본인 외 사용자)")
     @GetMapping("/answered")
     fun getMyAnsweredQuestions(
+        @ApiIgnore @AuthenticationPrincipal user: User?,
         @RequestParam userId: ObjectId,
         @RequestParam size: Int,
         @RequestParam(required = false) lastId: ObjectId?,
     ): ApiResponse<AnsweredQuestionsDto> {
         return questionService.findAnswerCompleteByToUser(
-            userId = userId,
+            authUser = user,
+            toUserID = userId,
             lastId = lastId,
             size = size + 1,
         ).let {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
@@ -18,6 +18,22 @@ class QuestionController(
     private val questionService: QuestionService,
     private val answerService: AnswerService,
 ) {
+    @ApiOperation("질문/답변 단건 조회")
+    @GetMapping("/{questionId}")
+    fun getDetailById(
+        @ApiIgnore @AuthenticationPrincipal user: User,
+        @PathVariable questionId: ObjectId,
+    ): ApiResponse<QuestionDetailDto> {
+        return questionService.findDetailById(
+            user = user,
+            questionId = questionId,
+        ).let {
+            ApiResponse.success(
+                QuestionDetailDto.from(it)
+            )
+        }
+    }
+
     @ApiOperation("답변완료(본인 외 사용자)")
     @GetMapping("/answered")
     fun getMyAnsweredQuestions(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
@@ -21,7 +21,7 @@ class QuestionController(
     @ApiOperation("질문/답변 단건 조회")
     @GetMapping("/{questionId}")
     fun getDetailById(
-        @ApiIgnore @AuthenticationPrincipal user: User,
+        @ApiIgnore @AuthenticationPrincipal user: User?,
         @PathVariable questionId: ObjectId,
     ): ApiResponse<QuestionDetailDto> {
         return questionService.findDetailById(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/QuestionController.kt
@@ -32,11 +32,7 @@ class QuestionController(
         ).let {
             ApiResponse.success(
                 AnsweredQuestionsDto.from(
-                    questions = it.questions,
-                    userMapByUserId = it.userMapByUserId,
-                    answerMapByQuestionId = it.answerMapByQuestionId,
-                    answerLikeCountMapByAnswerId = it.answerLikeCountMapByAnswerId,
-                    userAnswerLikeMapByAnswerId = it.userAnswerLikeMapByAnswerId,
+                    questions = it,
                     requestedSize = size,
                 )
             )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -104,7 +104,8 @@ class UserController(
         @RequestParam(required = false) lastId: ObjectId?,
     ): ApiResponse<AnsweredQuestionsDto> {
         return questionService.findAnswerCompleteByToUser(
-            user = user,
+            authUser = user,
+            toUser = user,
             lastId = lastId,
             size = size + 1,
         ).let {
@@ -125,7 +126,7 @@ class UserController(
         @RequestParam(required = false) lastId: ObjectId?,
     ): ApiResponse<ReceivedQuestionsDto> {
         return questionService.findAnswerWaitingByToUser(
-            user = user,
+            toUser = user,
             lastId = lastId,
             size = size + 1,
         ).let {
@@ -146,7 +147,7 @@ class UserController(
         @RequestParam(required = false) lastId: ObjectId?,
     ): ApiResponse<AskedQuestionsDto> {
         return questionService.findByFromUser(
-            user = user,
+            fromUser = user,
             lastId = lastId,
             size = size + 1,
         ).let {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -37,6 +37,22 @@ class UserController(
         return ApiResponse.success(UserInfoDto.from(userService.getUserInfo(userId)))
     }
 
+    @ApiOperation("유저 링크 공유")
+    @GetMapping("/{userId}/link-share")
+    fun getUserLinkShareInfo(
+        @ApiIgnore @AuthenticationPrincipal authUser: User?,
+        @PathVariable userId: ObjectId
+    ): ApiResponse<UserLinkShareInfoDto> {
+        val user = userService.getUserInfo(userId)
+        val questions = questionService.findAnswerCompleteByToUser(
+            authUser = authUser,
+            toUserID = userId,
+            lastId = null,
+            size = 2,
+        )
+        return ApiResponse.success(UserLinkShareInfoDto.from(user, questions))
+    }
+
     @ApiOperation("닉네임 설정")
     @PostMapping("/nickname")
     fun createNickname(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -110,11 +110,7 @@ class UserController(
         ).let {
             ApiResponse.success(
                 AnsweredQuestionsDto.from(
-                    questions = it.questions,
-                    userMapByUserId = it.userMapByUserId,
-                    answerMapByQuestionId = it.answerMapByQuestionId,
-                    answerLikeCountMapByAnswerId = it.answerLikeCountMapByAnswerId,
-                    userAnswerLikeMapByAnswerId = it.userAnswerLikeMapByAnswerId,
+                    questions = it,
                     requestedSize = size,
                 )
             )
@@ -135,8 +131,7 @@ class UserController(
         ).let {
             ApiResponse.success(
                 ReceivedQuestionsDto.from(
-                    questions = it.questions,
-                    userMapByUserId = it.userMapByUserId,
+                    questions = it,
                     requestedSize = size,
                 )
             )
@@ -157,8 +152,7 @@ class UserController(
         ).let {
             ApiResponse.success(
                 AskedQuestionsDto.from(
-                    questions = it.questions,
-                    userMapByUserId = it.userMapByUserId,
+                    questions = it,
                     requestedSize = size,
                 )
             )

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
@@ -37,6 +37,56 @@ data class AnswerEditRequest(
 )
 
 // Response
+data class QuestionDetailDto(
+    val id: String,
+    val content: String,
+    val representativeAddress: String?,
+    val anonymous: Boolean?,
+    val fromUser: QuestionUserDto,
+    val toUser: QuestionUserDto,
+    val answer: AnswerDto?,
+    val createdAt: LocalDateTime,
+) {
+    data class AnswerDto(
+        val id: String,
+        val content: String,
+        val representativeAddress: String?,
+        val user: QuestionUserDto,
+        val likeCount: Long,
+        val userLiked: Boolean,
+        val createdAt: LocalDateTime,
+    ) {
+        companion object {
+            fun from(answer: AnswerDomain): AnswerDto {
+                return AnswerDto(
+                    id = answer.id,
+                    content = answer.content,
+                    representativeAddress = answer.representativeAddress,
+                    user = QuestionUserDto.from(answer.user),
+                    likeCount = answer.likeCount,
+                    userLiked = answer.userLiked,
+                    createdAt = answer.createdAt,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun from(question: QuestionDomain): QuestionDetailDto {
+            return QuestionDetailDto(
+                id = question.id,
+                content = question.content,
+                representativeAddress = question.representativeAddress,
+                anonymous = question.anonymous,
+                fromUser = QuestionUserDto.from(question.fromUser),
+                toUser = QuestionUserDto.from(question.toUser),
+                answer = question.answer?.let { AnswerDto.from(question.answer) },
+                createdAt = question.createdAt,
+            )
+        }
+    }
+}
+
 data class AnsweredQuestionsDto(
     val questions: List<QuestionDto>,
     val hasNext: Boolean,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
@@ -1,10 +1,9 @@
 package kr.mashup.bangwidae.asked.controller.dto
 
 import io.swagger.annotations.ApiModelProperty
-import kr.mashup.bangwidae.asked.model.User
-import kr.mashup.bangwidae.asked.model.question.Answer
-import kr.mashup.bangwidae.asked.model.question.AnswerLike
-import kr.mashup.bangwidae.asked.model.question.Question
+import kr.mashup.bangwidae.asked.service.question.AnswerDomain
+import kr.mashup.bangwidae.asked.service.question.QuestionDomain
+import kr.mashup.bangwidae.asked.service.question.QuestionUserDomain
 import org.bson.types.ObjectId
 import java.time.LocalDateTime
 import kotlin.math.min
@@ -46,28 +45,23 @@ data class AnsweredQuestionsDto(
         val id: String,
         val content: String,
         val representativeAddress: String?,
+        val anonymous: Boolean?,
         val fromUser: QuestionUserDto,
         val toUser: QuestionUserDto,
         val answer: AnswerDto,
         val createdAt: LocalDateTime,
     ) {
         companion object {
-            fun from(
-                question: Question,
-                answer: Answer,
-                fromUser: User,
-                toUser: User,
-                answerLikeCount: Long,
-                answerLiked: Boolean
-            ): QuestionDto {
+            fun from(question: QuestionDomain): QuestionDto {
                 return QuestionDto(
-                    id = question.id!!.toHexString(),
+                    id = question.id,
                     content = question.content,
                     representativeAddress = question.representativeAddress,
-                    fromUser = if (question.anonymous == true) QuestionUserDto.anonymous(fromUser) else QuestionUserDto.from(fromUser),
-                    toUser = QuestionUserDto.from(toUser),
-                    answer = AnswerDto.from(answer, toUser, answerLikeCount, answerLiked),
-                    createdAt = question.createdAt!!,
+                    anonymous = question.anonymous,
+                    fromUser = QuestionUserDto.from(question.fromUser),
+                    toUser = QuestionUserDto.from(question.toUser),
+                    answer = AnswerDto.from(question.answer!!),
+                    createdAt = question.createdAt,
                 )
             }
         }
@@ -83,15 +77,15 @@ data class AnsweredQuestionsDto(
         val createdAt: LocalDateTime,
     ) {
         companion object {
-            fun from(answer: Answer, answerUser: User, likeCount: Long, userLiked: Boolean): AnswerDto {
+            fun from(answer: AnswerDomain): AnswerDto {
                 return AnswerDto(
-                    id = answer.id!!.toHexString(),
+                    id = answer.id,
                     content = answer.content,
                     representativeAddress = answer.representativeAddress,
-                    user = QuestionUserDto.from(answerUser),
-                    likeCount = likeCount,
-                    userLiked = userLiked,
-                    createdAt = answer.createdAt!!,
+                    user = QuestionUserDto.from(answer.user),
+                    likeCount = answer.likeCount,
+                    userLiked = answer.userLiked,
+                    createdAt = answer.createdAt,
                 )
             }
         }
@@ -99,26 +93,13 @@ data class AnsweredQuestionsDto(
 
     companion object {
         fun from(
-            questions: List<Question>,
-            userMapByUserId: Map<ObjectId, User>,
-            answerMapByQuestionId: Map<ObjectId, List<Answer>>,
-            answerLikeCountMapByAnswerId: Map<ObjectId, Long>,
-            userAnswerLikeMapByAnswerId: Map<ObjectId, AnswerLike>,
+            questions: List<QuestionDomain>,
             requestedSize: Int,
         ): AnsweredQuestionsDto {
             return AnsweredQuestionsDto(
-                questions = questions.subList(0, min(questions.size, requestedSize))
-                    .map {
-                        val answer = answerMapByQuestionId[it.id]!!.first()
-                        QuestionDto.from(
-                            question = it,
-                            answer = answer,
-                            fromUser = userMapByUserId[it.fromUserId]!!,
-                            toUser = userMapByUserId[answer.userId]!!,
-                            answerLikeCount = answerLikeCountMapByAnswerId[answer.id!!] ?: 0,
-                            answerLiked = userAnswerLikeMapByAnswerId[answer.id] != null
-                        )
-                    },
+                questions = questions
+                    .subList(0, min(questions.size, requestedSize))
+                    .map { QuestionDto.from(it) },
                 hasNext = questions.size > requestedSize
             )
         }
@@ -133,19 +114,21 @@ data class ReceivedQuestionsDto(
         val id: String,
         val content: String,
         val representativeAddress: String?,
+        val anonymous: Boolean?,
         val fromUser: QuestionUserDto,
         val toUser: QuestionUserDto,
         val createdAt: LocalDateTime,
     ) {
         companion object {
-            fun from(question: Question, fromUser: User, toUser: User): QuestionDto {
+            fun from(question: QuestionDomain): QuestionDto {
                 return QuestionDto(
-                    id = question.id!!.toHexString(),
+                    id = question.id,
                     content = question.content,
                     representativeAddress = question.representativeAddress,
-                    fromUser = if (question.anonymous == true) QuestionUserDto.anonymous(fromUser) else QuestionUserDto.from(fromUser),
-                    toUser = QuestionUserDto.from(toUser),
-                    createdAt = question.createdAt!!,
+                    anonymous = question.anonymous,
+                    fromUser = QuestionUserDto.from(question.fromUser),
+                    toUser = QuestionUserDto.from(question.toUser),
+                    createdAt = question.createdAt,
                 )
             }
         }
@@ -153,19 +136,13 @@ data class ReceivedQuestionsDto(
 
     companion object {
         fun from(
-            questions: List<Question>,
-            userMapByUserId: Map<ObjectId, User>,
+            questions: List<QuestionDomain>,
             requestedSize: Int,
         ): ReceivedQuestionsDto {
             return ReceivedQuestionsDto(
                 questions = questions.subList(0, min(questions.size, requestedSize))
-                    .map {
-                        QuestionDto.from(
-                            question = it,
-                            fromUser = userMapByUserId[it.fromUserId]!!,
-                            toUser = userMapByUserId[it.toUserId]!!
-                        )
-                    },
+                    .subList(0, min(questions.size, requestedSize))
+                    .map { QuestionDto.from(it) },
                 hasNext = questions.size > requestedSize
             )
         }
@@ -180,19 +157,21 @@ data class AskedQuestionsDto(
         val id: String,
         val content: String,
         val representativeAddress: String?,
+        val anonymous: Boolean?,
         val fromUser: QuestionUserDto,
         val toUser: QuestionUserDto,
         val createdAt: LocalDateTime,
     ) {
         companion object {
-            fun from(question: Question, fromUser: User, toUser: User): QuestionDto {
+            fun from(question: QuestionDomain): QuestionDto {
                 return QuestionDto(
-                    id = question.id!!.toHexString(),
+                    id = question.id,
                     content = question.content,
                     representativeAddress = question.representativeAddress,
-                    fromUser = if (question.anonymous == true) QuestionUserDto.anonymous(fromUser) else QuestionUserDto.from(fromUser),
-                    toUser = QuestionUserDto.from(toUser),
-                    createdAt = question.createdAt!!,
+                    anonymous = question.anonymous,
+                    fromUser = QuestionUserDto.from(question.fromUser),
+                    toUser = QuestionUserDto.from(question.toUser),
+                    createdAt = question.createdAt,
                 )
             }
         }
@@ -200,19 +179,13 @@ data class AskedQuestionsDto(
 
     companion object {
         fun from(
-            questions: List<Question>,
-            userMapByUserId: Map<ObjectId, User>,
+            questions: List<QuestionDomain>,
             requestedSize: Int,
         ): AskedQuestionsDto {
             return AskedQuestionsDto(
                 questions = questions.subList(0, min(questions.size, requestedSize))
-                    .map {
-                        QuestionDto.from(
-                            question = it,
-                            fromUser = userMapByUserId[it.fromUserId]!!,
-                            toUser = userMapByUserId[it.toUserId]!!
-                        )
-                    },
+                    .subList(0, min(questions.size, requestedSize))
+                    .map { QuestionDto.from(it) },
                 hasNext = questions.size > requestedSize
             )
         }
@@ -220,31 +193,18 @@ data class AskedQuestionsDto(
 }
 
 data class QuestionUserDto(
-    val anonymous: Boolean,
     val id: String,
     val nickname: String,
     val tags: List<String>,
     val profileImageUrl: String?,
 ) {
     companion object {
-        fun from(user: User): QuestionUserDto {
+        fun from(user: QuestionUserDomain): QuestionUserDto {
             return QuestionUserDto(
-                anonymous = false,
-                id = user.id!!.toHexString(),
-                nickname = user.nickname!!,
+                id = user.id,
+                nickname = user.nickname,
                 tags = user.tags,
-                profileImageUrl = user.profileImageUrl
-            )
-        }
-
-        fun anonymous(user: User): QuestionUserDto {
-            return QuestionUserDto(
-                anonymous = true,
-                id = user.id!!.toHexString(),
-                nickname = "익명",
-                tags = emptyList(),
-                // TODO 기본 익명 이미지 Url 로 설정
-                profileImageUrl = "default profileImageUrl"
+                profileImageUrl = user.profileImageUrl,
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
@@ -1,6 +1,8 @@
 package kr.mashup.bangwidae.asked.controller.dto
 
 import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.model.User.Companion.DEFAULT_PROFILE_IMAGE_URL
+import kr.mashup.bangwidae.asked.service.question.QuestionDomain
 
 data class UserInfoDto(
     val userId: String,
@@ -17,6 +19,54 @@ data class UserInfoDto(
                 tags = user.tags,
             )
         }
+    }
+}
+
+data class UserLinkShareInfoDto(
+    val user: UserInfoDto,
+    val representativeWardName: String,
+    val questions: List<QuestionAndAnswerDto>,
+) {
+    data class UserInfoDto(
+        val id: String,
+        val nickname: String,
+        val profileDescription: String,
+        val tags: List<String>,
+        val profileImageUrl: String,
+        val level: Int,
+    ) {
+        companion object {
+            fun from(user: User) = UserInfoDto(
+                id = user.id!!.toHexString(),
+                nickname = user.nickname!!,
+                profileDescription = user.description ?: "",
+                tags = user.tags,
+                profileImageUrl = user.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
+                level = user.level,
+            )
+        }
+    }
+
+    data class QuestionAndAnswerDto(
+        val questionId: String,
+        val questionContent: String,
+        val answerContent: String,
+    ) {
+        companion object {
+            fun from(question: QuestionDomain) = QuestionAndAnswerDto(
+                questionId = question.id,
+                questionContent = question.content,
+                answerContent = question.answer!!.content,
+            )
+        }
+    }
+
+    companion object {
+        fun from(user: User, questions: List<QuestionDomain>) = UserLinkShareInfoDto(
+            user = UserInfoDto.from(user),
+            representativeWardName = "todo - 우리집",
+            questions = questions.map { QuestionAndAnswerDto.from(it) },
+        )
     }
 }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeAggregator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerLikeAggregator.kt
@@ -25,6 +25,10 @@ class AnswerLikeAggregator(
             .associateBy { it.answerId }
             .mapValues { it.value.likeCount }
     }
+
+    fun getCountByAnswerId(answerId: ObjectId): Long {
+        return getCountGroupByAnswerId(listOf(answerId))[answerId] ?: 0
+    }
 }
 
 data class AnswerLikeCountGroupByAnswerId(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
@@ -11,5 +11,6 @@ interface AnswerRepository : MongoRepository<Answer, ObjectId> {
     fun findByIdAndDeletedFalse(id: ObjectId): Answer?
     fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun countByQuestionIdAndDeletedFalse(questionId: ObjectId): Long
+    fun findByQuestionIdAndDeletedFalse(id: ObjectId): List<Answer>
     fun findByQuestionIdInAndDeletedFalseOrderByCreatedAtDesc(ids: List<ObjectId>): List<Answer>
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/AnswerRepository.kt
@@ -11,6 +11,5 @@ interface AnswerRepository : MongoRepository<Answer, ObjectId> {
     fun findByIdAndDeletedFalse(id: ObjectId): Answer?
     fun existsByIdAndDeletedFalse(id: ObjectId): Boolean
     fun countByQuestionIdAndDeletedFalse(questionId: ObjectId): Long
-    fun findByQuestionIdAndDeletedFalse(id: ObjectId): List<Answer>
     fun findByQuestionIdInAndDeletedFalseOrderByCreatedAtDesc(ids: List<ObjectId>): List<Answer>
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/UserRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/UserRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface UserRepository : MongoRepository<User, ObjectId> {
     fun findByEmail(email: String): User?
-    fun findAllByIdIn(idList: List<ObjectId>): List<User>
+    fun findAllByIdIn(idList: Collection<ObjectId>): List<User>
     fun findByNickname(nickname: String): User?
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AnswerService(
     private val placeService: PlaceService,
+    private val levelPolicyService: LevelPolicyService,
     private val answerRepository: AnswerRepository,
     private val answerLikeRepository: AnswerLikeRepository,
     private val questionRepository: QuestionRepository,
@@ -45,6 +46,7 @@ class AnswerService(
                 latitude = request.latitude
             )
         }.getOrNull().let {
+            levelPolicyService.levelUpIfConditionSatisfied(user)
             return answerRepository.save(
                 Answer(
                     userId = user.id!!,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionDomain.kt
@@ -1,0 +1,83 @@
+package kr.mashup.bangwidae.asked.service.question
+
+import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.model.question.Answer
+import kr.mashup.bangwidae.asked.model.question.Question
+import java.time.LocalDateTime
+
+data class QuestionDomain(
+    val id: String,
+    val content: String,
+    val representativeAddress: String?,
+    val anonymous: Boolean?,
+    val fromUser: QuestionUserDomain,
+    val toUser: QuestionUserDomain,
+    val answer: AnswerDomain?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(
+            question: Question,
+            fromUser: User,
+            toUser: User,
+            answer: Answer? = null,
+            answerLikeCount: Long? = null,
+            answerUserLiked: Boolean? = null,
+        ) = QuestionDomain(
+            id = question.id!!.toHexString(),
+            content = question.content,
+            representativeAddress = question.representativeAddress,
+            anonymous = question.anonymous,
+            fromUser = if (question.anonymous == true) QuestionUserDomain.from(fromUser.getAnonymousUser())
+            else QuestionUserDomain.from(fromUser),
+            toUser = QuestionUserDomain.from(toUser),
+            answer = answer?.let {
+                AnswerDomain.from(
+                    answer = it,
+                    user = toUser,
+                    likeCount = answerLikeCount!!,
+                    userLiked = answerUserLiked!!,
+                )
+            },
+            createdAt = question.createdAt!!,
+        )
+    }
+}
+
+data class AnswerDomain(
+    val id: String,
+    val content: String,
+    val representativeAddress: String?,
+    val user: QuestionUserDomain,
+    val likeCount: Long,
+    val userLiked: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(answer: Answer, user: User, likeCount: Long, userLiked: Boolean) = AnswerDomain(
+            id = answer.id!!.toHexString(),
+            content = answer.content,
+            representativeAddress = answer.representativeAddress,
+            user = QuestionUserDomain.from(user),
+            likeCount = likeCount,
+            userLiked = userLiked,
+            createdAt = answer.createdAt!!,
+        )
+    }
+}
+
+data class QuestionUserDomain(
+    val id: String,
+    val nickname: String,
+    val tags: List<String>,
+    val profileImageUrl: String?,
+) {
+    companion object {
+        fun from(user: User) = QuestionUserDomain(
+            id = user.id!!.toString(),
+            nickname = user.nickname!!,
+            tags = user.tags,
+            profileImageUrl = user.profileImageUrl,
+        )
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -34,7 +34,7 @@ class QuestionService(
     fun findDetailById(authUser: User?, questionId: ObjectId): QuestionDomain {
         val question = findById(questionId)
 
-        return listOf(question).toDomain(authUser).first()
+        return question.toDomain(authUser)
     }
 
     fun findAnswerWaitingByToUser(toUser: User, lastId: ObjectId?, size: Int): List<QuestionDomain> {
@@ -88,6 +88,10 @@ class QuestionService(
         )
 
         return questions.toDomain(fromUser)
+    }
+
+    private fun Question.toDomain(authUser: User?): QuestionDomain {
+        return listOf(this).toDomain(authUser).first()
     }
 
     private fun List<Question>.toDomain(authUser: User?): List<QuestionDomain> {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class QuestionService(
     private val placeService: PlaceService,
+    private val levelPolicyService: LevelPolicyService,
     private val questionRepository: QuestionRepository,
     private val answerRepository: AnswerRepository,
     private val answerLikeRepository: AnswerLikeRepository,
@@ -141,6 +142,7 @@ class QuestionService(
                 latitude = request.latitude
             )
         }.getOrNull().let {
+            levelPolicyService.levelUpIfConditionSatisfied(user)
             return questionRepository.save(
                 Question(
                     fromUserId = user.id!!,


### PR DESCRIPTION
## Related Issue
#101 #102 

## 설명
- 기존 코드는 Service에서 각 모델을 반환하고 Dto에서 조인(매칭)하는 구조라 비즈니스 로직이 Dto에 혼재했습니다.
- Service는 DB 종속적인 모델이 아닌 자체 정의한 도메인 객체(~Domain)를 반환하고 모델 간 조인 로직을 Service에서 진행하도록 수정해 봤습니다.
- Dto는 도메인 객체를 최종 응답 스펙으로 변환해 주는 역할만 하도록 했습니다.
- 덤으로 질문, 답변 작성 시 레벨업 체크 로직 슬쩍 끼워 넣었습니다.

리뷰 적극 환영!