### PR TITLE
사용자 링크 공유 API

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig {
                 "/api/v1/auth/mail/cert",
                 "/api/v1/questions/{questionId}",
                 "/api/v1/questions/answered",
+                "/api/v1/user/{userId}/link-share"
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -37,6 +37,22 @@ class UserController(
         return ApiResponse.success(UserInfoDto.from(userService.getUserInfo(userId)))
     }
 
+    @ApiOperation("유저 링크 공유")
+    @GetMapping("/{userId}/link-share")
+    fun getUserLinkShareInfo(
+        @ApiIgnore @AuthenticationPrincipal authUser: User?,
+        @PathVariable userId: ObjectId
+    ): ApiResponse<UserLinkShareInfoDto> {
+        val user = userService.getUserInfo(userId)
+        val questions = questionService.findAnswerCompleteByToUser(
+            authUser = authUser,
+            toUserID = userId,
+            lastId = null,
+            size = 2,
+        )
+        return ApiResponse.success(UserLinkShareInfoDto.from(user, questions))
+    }
+
     @ApiOperation("닉네임 설정")
     @PostMapping("/nickname")
     fun createNickname(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
@@ -1,6 +1,8 @@
 package kr.mashup.bangwidae.asked.controller.dto
 
 import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.model.User.Companion.DEFAULT_PROFILE_IMAGE_URL
+import kr.mashup.bangwidae.asked.service.question.QuestionDomain
 
 data class UserInfoDto(
     val userId: String,
@@ -17,6 +19,54 @@ data class UserInfoDto(
                 tags = user.tags,
             )
         }
+    }
+}
+
+data class UserLinkShareInfoDto(
+    val user: UserInfoDto,
+    val representativeWardName: String,
+    val questions: List<QuestionAndAnswerDto>,
+) {
+    data class UserInfoDto(
+        val id: String,
+        val nickname: String,
+        val profileDescription: String,
+        val tags: List<String>,
+        val profileImageUrl: String,
+        val level: Int,
+    ) {
+        companion object {
+            fun from(user: User) = UserInfoDto(
+                id = user.id!!.toHexString(),
+                nickname = user.nickname!!,
+                profileDescription = user.description ?: "",
+                tags = user.tags,
+                profileImageUrl = user.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
+                level = user.level,
+            )
+        }
+    }
+
+    data class QuestionAndAnswerDto(
+        val questionId: String,
+        val questionContent: String,
+        val answerContent: String,
+    ) {
+        companion object {
+            fun from(question: QuestionDomain) = QuestionAndAnswerDto(
+                questionId = question.id,
+                questionContent = question.content,
+                answerContent = question.answer!!.content,
+            )
+        }
+    }
+
+    companion object {
+        fun from(user: User, questions: List<QuestionDomain>) = UserLinkShareInfoDto(
+            user = UserInfoDto.from(user),
+            representativeWardName = "todo - 우리집",
+            questions = questions.map { QuestionAndAnswerDto.from(it) },
+        )
     }
 }
 


### PR DESCRIPTION
## 설명
- 사용자 링크 공유 시 userId로 노출 필요한 데이터를 조회하는 API 입니당
- 기존에 클라이언트에 모킹으로 제공한 스펙이 있어서 그거에 맞게 맞췄습니다
- Controller method 한 개에서 Service 복수 개 호출하는거가 제일 구현이 간편할 거 같아서 예외적으로 허용해 줬습니다..ㅎㅎㅠ