### PR TITLE
levelup 추가, leveluppolicy 서비스 위치 변경, also 사용

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/AnswerController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/AnswerController.kt
@@ -52,7 +52,7 @@ class AnswerController(
     fun likeAnswer(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        answerService.answerLike(id, user.id!!)
+        answerService.answerLike(id, user)
         return ApiResponse.success(true)
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/CommentController.kt
@@ -55,7 +55,7 @@ class CommentController(
     fun likeComment(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        commentLikeService.commentLike(id, user.id!!)
+        commentLikeService.commentLike(id, user)
         return ApiResponse.success(true)
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PostController.kt
@@ -26,7 +26,7 @@ class PostController(
         @ApiIgnore @AuthenticationPrincipal user: User, @RequestBody postWriteRequest: PostWriteRequest
     ): ApiResponse<PostResultDto> {
         val post = postWriteRequest.toEntity(user.id!!)
-        return postService.write(post)
+        return postService.write(user, post)
             .let {
                 ApiResponse.success(PostResultDto.from(user, it))
             }
@@ -62,7 +62,7 @@ class PostController(
     fun likePost(
         @ApiIgnore @AuthenticationPrincipal user: User, @PathVariable id: ObjectId
     ): ApiResponse<Boolean> {
-        postLikeService.postLike(id, user.id!!)
+        postLikeService.postLike(id, user)
         return ApiResponse.success(true)
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
@@ -15,7 +15,7 @@ data class LevelPolicy (
     val wardCount: Int,
 ) {
     fun isSatisfiedLevelUp(userWardCount: Int, userAnswerCount: Int, userQuestionCount: Int): Boolean {
-        return userWardCount >= wardCount &&
+        return userWardCount >= wardCountCondition &&
                 userAnswerCount >= answerCountCondition &&
                 userQuestionCount >= questionCountCondition
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/LevelPolicyService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/LevelPolicyService.kt
@@ -1,4 +1,4 @@
-package kr.mashup.bangwidae.asked.service.question
+package kr.mashup.bangwidae.asked.service
 
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.repository.*

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
@@ -15,6 +15,7 @@ import java.time.LocalDateTime
 class WardService(
     private val wardRepository: WardRepository,
     private val levelPolicyRepository: LevelPolicyRepository,
+    private val levelPolicyService: LevelPolicyService
 ) {
     fun createWard(user: User, name: String, longitude: Double, latitude: Double): Boolean {
         val userLevelPolicy = levelPolicyRepository.findByLevel(user.level)
@@ -30,6 +31,7 @@ class WardService(
             location = GeoUtils.geoJsonPoint(longitude, latitude)
         )
         wardRepository.save(ward)
+        levelPolicyService.levelUpIfConditionSatisfied(user)
         return true
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
@@ -7,7 +7,6 @@ import kr.mashup.bangwidae.asked.model.post.Comment
 import kr.mashup.bangwidae.asked.model.post.CommentLike
 import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
 import kr.mashup.bangwidae.asked.repository.CommentRepository
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
@@ -15,16 +14,13 @@ import org.springframework.stereotype.Service
 class CommentLikeService(
     private val commentLikeRepository: CommentLikeRepository,
     private val commentRepository: CommentRepository,
-    private val levelPolicyService: LevelPolicyService,
 ) {
     fun commentLike(commentId: ObjectId, user: User) {
         require(commentRepository.existsByIdAndDeletedFalse(commentId)) {
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
         }
         if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, user.id!!)) {
-            commentLikeRepository.save(CommentLike(userId = user.id, commentId = commentId)).also {
-                levelPolicyService.levelUpIfConditionSatisfied(user)
-            }
+            commentLikeRepository.save(CommentLike(userId = user.id, commentId = commentId))
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentLikeService.kt
@@ -2,24 +2,29 @@ package kr.mashup.bangwidae.asked.service.post
 
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Comment
 import kr.mashup.bangwidae.asked.model.post.CommentLike
 import kr.mashup.bangwidae.asked.repository.CommentLikeRepository
 import kr.mashup.bangwidae.asked.repository.CommentRepository
+import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
 @Service
 class CommentLikeService(
     private val commentLikeRepository: CommentLikeRepository,
-    private val commentRepository: CommentRepository
+    private val commentRepository: CommentRepository,
+    private val levelPolicyService: LevelPolicyService,
 ) {
-    fun commentLike(commentId: ObjectId, userId: ObjectId) {
+    fun commentLike(commentId: ObjectId, user: User) {
         require(commentRepository.existsByIdAndDeletedFalse(commentId)) {
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
         }
-        if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
-            commentLikeRepository.save(CommentLike(userId = userId, commentId = commentId))
+        if (!commentLikeRepository.existsByCommentIdAndUserId(commentId, user.id!!)) {
+            commentLikeRepository.save(CommentLike(userId = user.id, commentId = commentId)).also {
+                levelPolicyService.levelUpIfConditionSatisfied(user)
+            }
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
@@ -7,7 +7,6 @@ import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.model.post.PostLike
 import kr.mashup.bangwidae.asked.repository.PostLikeRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
@@ -15,16 +14,13 @@ import org.springframework.stereotype.Service
 class PostLikeService(
     private val postLikeRepository: PostLikeRepository,
     private val postRepository: PostRepository,
-    private val levelPolicyService: LevelPolicyService,
 ) {
     fun postLike(postId: ObjectId, user: User) {
         require(postRepository.existsByIdAndDeletedFalse(postId)) {
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
         }
         if (!postLikeRepository.existsByPostIdAndUserId(postId, user.id!!)) {
-            postLikeRepository.save(PostLike(userId = user.id, postId = postId)).also {
-                levelPolicyService.levelUpIfConditionSatisfied(user)
-            }
+            postLikeRepository.save(PostLike(userId = user.id, postId = postId))
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostLikeService.kt
@@ -2,24 +2,29 @@ package kr.mashup.bangwidae.asked.service.post
 
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
+import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.model.post.PostLike
 import kr.mashup.bangwidae.asked.repository.PostLikeRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
+import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
 @Service
 class PostLikeService(
     private val postLikeRepository: PostLikeRepository,
-    private val postRepository: PostRepository
+    private val postRepository: PostRepository,
+    private val levelPolicyService: LevelPolicyService,
 ) {
-    fun postLike(postId: ObjectId, userId: ObjectId) {
+    fun postLike(postId: ObjectId, user: User) {
         require(postRepository.existsByIdAndDeletedFalse(postId)) {
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
         }
-        if (!postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
-            postLikeRepository.save(PostLike(userId = userId, postId = postId))
+        if (!postLikeRepository.existsByPostIdAndUserId(postId, user.id!!)) {
+            postLikeRepository.save(PostLike(userId = user.id, postId = postId)).also {
+                levelPolicyService.levelUpIfConditionSatisfied(user)
+            }
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -8,6 +8,7 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.repository.PostRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
+import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import kr.mashup.bangwidae.asked.utils.getLatitude
@@ -25,15 +26,18 @@ class PostService(
     private val placeService: PlaceService,
     private val userRepository: UserRepository,
     private val postLikeService: PostLikeService,
-    private val commentService: CommentService
+    private val commentService: CommentService,
+    private val levelPolicyService: LevelPolicyService
 ) : WithPostAuthorityValidator {
     fun findById(id: ObjectId): Post {
         return postRepository.findByIdAndDeletedFalse(id)
             ?: throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
     }
 
-    fun write(post: Post): Post {
-        return postRepository.save(updatePlaceInfo(post))
+    fun write(user: User, post: Post): Post {
+        return postRepository.save(updatePlaceInfo(post)).also {
+            levelPolicyService.levelUpIfConditionSatisfied(user)
+        }
     }
 
     fun edit(user: User, postId: ObjectId, request: PostEditRequest): Post {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
@@ -89,9 +89,7 @@ class AnswerService(
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
         }
         if (!answerLikeRepository.existsByAnswerIdAndUserId(answerId, user.id!!)) {
-            answerLikeRepository.save(AnswerLike(userId = user.id, answerId = answerId)).also {
-                levelPolicyService.levelUpIfConditionSatisfied(user)
-            }
+            answerLikeRepository.save(AnswerLike(userId = user.id, answerId = answerId))
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -7,6 +7,7 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.question.Question
 import kr.mashup.bangwidae.asked.model.question.QuestionStatus
 import kr.mashup.bangwidae.asked.repository.*
+import kr.mashup.bangwidae.asked.service.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
@@ -137,7 +138,6 @@ class QuestionService(
                 latitude = request.latitude
             )
         }.getOrNull().let {
-            levelPolicyService.levelUpIfConditionSatisfied(user)
             return questionRepository.save(
                 Question(
                     fromUserId = user.id!!,
@@ -148,7 +148,9 @@ class QuestionService(
                     representativeAddress = it?.representativeAddress,
                     region = it,
                 )
-            )
+            ).also {
+                levelPolicyService.levelUpIfConditionSatisfied(user)
+            }
         }
     }
 


### PR DESCRIPTION
1) 성윤이 작업한거중에 answerLike 에 레벨업 체크하는거 빠져있어서 추가
2) levelupPolicyService 위치가 question안에 있었는데 이거 post, comment에서도 쓰는거라 question안에 안있고 그 상위로 패키지 올림
3) 성윤이 로직이 a) 레벨업 체크를 해서 레벨올린다 b) xxx를 쓴다(저장한다) 의 로직인데, xxx를 쓴 행동이 db에 반영되고 나서 레벨업체크를 해서 레벨을 올리는게 맞는거같아서 also를 사용하도록 작업하고 성윤이 작업도 수정하였습니다.

피드백환영 피-환