### PR TITLE
QuestionDto 정의 및 representativeAddress 추가 반환

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/PlaceController.kt
@@ -3,7 +3,7 @@ package kr.mashup.bangwidae.asked.controller
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import kr.mashup.bangwidae.asked.controller.dto.ApiResponse
-import kr.mashup.bangwidae.asked.model.Region
+import kr.mashup.bangwidae.asked.controller.dto.PlaceDto
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import org.springframework.web.bind.annotation.*
 
@@ -13,18 +13,15 @@ import org.springframework.web.bind.annotation.*
 class PlaceController(
     private val placeService: PlaceService,
 ) {
-    // TODO 필요한 응답 포맷 확인 후 DTO 반환하도록 수정
     @ApiOperation("위경도를 주소로 변환")
     @GetMapping("/reverse/geocode")
     fun reverseGeocode(
         @RequestParam latitude: Double,
         @RequestParam longitude: Double,
-    ): ApiResponse<Region> {
+    ): ApiResponse<PlaceDto> {
         return placeService.reverseGeocode(
             longitude = longitude,
             latitude = latitude,
-        ).let {
-            ApiResponse.success(it)
-        }
+        ).let { ApiResponse.success(PlaceDto.from(it)) }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PlaceDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PlaceDto.kt
@@ -1,0 +1,28 @@
+package kr.mashup.bangwidae.asked.controller.dto
+
+import kr.mashup.bangwidae.asked.model.Region
+import kr.mashup.bangwidae.asked.service.place.Nationality
+
+data class PlaceDto(
+    val 국가: Nationality?,
+    val 도: String?,
+    val 시: String?,
+    val 군구: String?,
+    val 읍면동: String?,
+    val 리: String?,
+    val representativeAddress: String,
+) {
+    companion object {
+        fun from(region: Region): PlaceDto {
+            return PlaceDto(
+                국가 = region.국가,
+                도 = region.도,
+                시 = region.시,
+                군구 = region.군구,
+                읍면동 = region.읍면동,
+                리 = region.리,
+                representativeAddress = region.representativeAddress,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/Region.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/Region.kt
@@ -1,5 +1,7 @@
 package kr.mashup.bangwidae.asked.model
 
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.service.place.Nationality
 
 data class Region(
@@ -10,6 +12,7 @@ data class Region(
     val 읍면동: String?,
     val 리: String?,
 ) {
-    val representativeAddress: String?
+    val representativeAddress: String
         get() = 군구 ?: 시 ?: 읍면동 ?: 리 ?: 도
+        ?: throw DoriDoriException.of(DoriDoriExceptionType.REPRESENTATIVE_ADDRESS_NOT_EXIST)
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/place/PlaceService.kt
@@ -21,12 +21,6 @@ class PlaceService(
 
         return region
     }
-
-    fun getRepresentativeAddress(longitude: Double, latitude: Double): String {
-        val region = reverseGeocode(longitude, latitude)
-        return region.군구 ?: region.시 ?: region.읍면동 ?: region.리 ?: region.도
-        ?: throw DoriDoriException.of(DoriDoriExceptionType.REPRESENTATIVE_ADDRESS_NOT_EXIST)
-    }
 }
 
 enum class Nationality {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -93,7 +93,6 @@ class PostService(
         val longitude = post.location.getLongitude()
         val latitude = post.location.getLatitude()
         val region = placeService.reverseGeocode(longitude, latitude)
-        val representativeAddress = placeService.getRepresentativeAddress(longitude, latitude)
-        return post.copy(representativeAddress = representativeAddress, region = region)
+        return post.copy(representativeAddress = region.representativeAddress, region = region)
     }
 }


### PR DESCRIPTION
## 설명
- 위경도 변환 API가 모델을 그대로 반환하고 있어서 Dto를 추가했습니다.
- representativeAddress를 판단하는 로직이 두 곳에 분산되어 있어 하나로 통일했습니다.

## Related Issue
#103 