### PR TITLE
유저 레벨 정책 조회 관련 추가, 이미지 url 추가

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -49,7 +49,7 @@ class SecurityConfig {
                 "/api/v1/questions/{questionId}",
                 "/api/v1/questions/answered",
                 "/api/v1/user/{userId}/link-share",
-                "/api/v1/level-policy/{level}"
+                "/api/v1/level-policy/{level}",
                 "/api/v1/posts/near",
                 "/api/v1/posts/{postId}",
                 "/api/v1/posts/{postId}/comment"

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/config/auth/security/SecurityConfig.kt
@@ -48,7 +48,8 @@ class SecurityConfig {
                 "/api/v1/auth/mail/cert",
                 "/api/v1/questions/{questionId}",
                 "/api/v1/questions/answered",
-                "/api/v1/user/{userId}/link-share"
+                "/api/v1/user/{userId}/link-share",
+                "/api/v1/level-policy/{level}"
             ).permitAll()
             .antMatchers("/api/**").hasAuthority("ROLE")
         http.csrf().disable()

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/LevelPolicyController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/LevelPolicyController.kt
@@ -1,0 +1,40 @@
+package kr.mashup.bangwidae.asked.controller
+
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import kr.mashup.bangwidae.asked.controller.dto.ApiResponse
+import kr.mashup.bangwidae.asked.controller.dto.LevelPolicyDto
+import kr.mashup.bangwidae.asked.controller.dto.UserAchievementDto
+import kr.mashup.bangwidae.asked.model.User
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import springfox.documentation.annotations.ApiIgnore
+
+@Api(tags = ["레벨 정책 컨트롤러"])
+@RestController
+@RequestMapping("/api/v1/level-policy")
+class LevelPolicyController(
+    private val levelPolicyService: LevelPolicyService
+) {
+    @ApiOperation("레벨 정책 조회")
+    @GetMapping("/{level}")
+    fun getLevelPolicy(
+        @PathVariable level: Int
+    ): ApiResponse<LevelPolicyDto> {
+        return levelPolicyService.getLevelPolicy(level)
+            .let { ApiResponse.success(LevelPolicyDto.from(it)) }
+    }
+
+    @ApiOperation("사용자 레벨 조건 달성 현황 조회")
+    @GetMapping("/achievement")
+    fun getUserAchievement(
+        @ApiIgnore @AuthenticationPrincipal authUser: User
+    ): ApiResponse<UserAchievementDto> {
+        return levelPolicyService.getUserAchievement(authUser)
+            .let { ApiResponse.success(UserAchievementDto.from(it)) }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/LevelPolicyDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/LevelPolicyDto.kt
@@ -7,7 +7,7 @@ data class LevelPolicyDto (
     val wardCountCondition: Int,
     val answerCountCondition: Int,
     val questionCountCondition: Int,
-    val wardCount: Int,
+    val maxWardCount: Int,
     val imageUrl: String
 ) {
     companion object {
@@ -17,7 +17,7 @@ data class LevelPolicyDto (
                 wardCountCondition = levelPolicy.wardCountCondition,
                 answerCountCondition = levelPolicy.answerCountCondition,
                 questionCountCondition = levelPolicy.questionCountCondition,
-                wardCount = levelPolicy.wardCount,
+                maxWardCount = levelPolicy.maxWardCount,
                 imageUrl = levelPolicy.imageUrl
             )
         }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/LevelPolicyDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/LevelPolicyDto.kt
@@ -1,0 +1,25 @@
+package kr.mashup.bangwidae.asked.controller.dto
+
+import kr.mashup.bangwidae.asked.model.LevelPolicy
+
+data class LevelPolicyDto (
+    val level: Int,
+    val wardCountCondition: Int,
+    val answerCountCondition: Int,
+    val questionCountCondition: Int,
+    val wardCount: Int,
+    val imageUrl: String
+) {
+    companion object {
+        fun from(levelPolicy: LevelPolicy): LevelPolicyDto{
+            return LevelPolicyDto(
+                level = levelPolicy.level,
+                wardCountCondition = levelPolicy.wardCountCondition,
+                answerCountCondition = levelPolicy.answerCountCondition,
+                questionCountCondition = levelPolicy.questionCountCondition,
+                wardCount = levelPolicy.wardCount,
+                imageUrl = levelPolicy.imageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserAchievementDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserAchievementDto.kt
@@ -1,0 +1,19 @@
+package kr.mashup.bangwidae.asked.controller.dto
+
+import kr.mashup.bangwidae.asked.service.levelpolicy.UserAchievement
+
+data class UserAchievementDto(
+    val userWardCount: Int,
+    val userAnswerCount: Int,
+    val userQuestionCount: Int
+) {
+    companion object {
+        fun from(userAchievement: UserAchievement): UserAchievementDto {
+            return UserAchievementDto(
+                userAnswerCount = userAchievement.userAnswerCount,
+                userWardCount = userAchievement.userWardCount,
+                userQuestionCount = userAchievement.userQuestionCount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserAchievementDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserAchievementDto.kt
@@ -3,6 +3,7 @@ package kr.mashup.bangwidae.asked.controller.dto
 import kr.mashup.bangwidae.asked.service.levelpolicy.UserAchievement
 
 data class UserAchievementDto(
+    val userLevel: Int,
     val userWardCount: Int,
     val userAnswerCount: Int,
     val userQuestionCount: Int
@@ -10,6 +11,7 @@ data class UserAchievementDto(
     companion object {
         fun from(userAchievement: UserAchievement): UserAchievementDto {
             return UserAchievementDto(
+                userLevel = userAchievement.userLevel,
                 userAnswerCount = userAchievement.userAnswerCount,
                 userWardCount = userAchievement.userWardCount,
                 userQuestionCount = userAchievement.userQuestionCount

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
@@ -13,6 +13,7 @@ data class LevelPolicy (
     val answerCountCondition: Int,
     val questionCountCondition: Int,
     val wardCount: Int,
+    val imageUrl: String
 ) {
     fun isSatisfiedLevelUp(userWardCount: Int, userAnswerCount: Int, userQuestionCount: Int): Boolean {
         return userWardCount >= wardCountCondition &&

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/LevelPolicy.kt
@@ -12,7 +12,7 @@ data class LevelPolicy (
     val wardCountCondition: Int,
     val answerCountCondition: Int,
     val questionCountCondition: Int,
-    val wardCount: Int,
+    val maxWardCount: Int,
     val imageUrl: String
 ) {
     fun isSatisfiedLevelUp(userWardCount: Int, userAnswerCount: Int, userQuestionCount: Int): Boolean {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
@@ -6,6 +6,7 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.Ward
 import kr.mashup.bangwidae.asked.repository.LevelPolicyRepository
 import kr.mashup.bangwidae.asked.repository.WardRepository
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
@@ -22,7 +22,7 @@ class WardService(
         val userLevelPolicy = levelPolicyRepository.findByLevel(user.level)
         val userWardCount = wardRepository.countAllByUserId(user.id!!)
 
-        if (userWardCount >= userLevelPolicy!!.wardCount) {
+        if (userWardCount >= userLevelPolicy!!.maxWardCount) {
             throw DoriDoriException.of(DoriDoriExceptionType.WARD_MAX_COUNT)
         }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/LevelPolicyService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/LevelPolicyService.kt
@@ -45,6 +45,7 @@ class LevelPolicyService(
         val commentAnswerCount = commentRepository.countAllByUserIdAndDeletedFalse(user.id)
         val postQuestionCount = postRepository.countAllByUserIdAndDeletedFalse(user.id)
         return UserAchievement(
+            userLevel = user.level,
             userWardCount = wardCount,
             userAnswerCount = answerCount + commentAnswerCount,
             userQuestionCount = questionCount + postQuestionCount

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/UserAchievement.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/UserAchievement.kt
@@ -1,6 +1,7 @@
 package kr.mashup.bangwidae.asked.service.levelpolicy
 
 data class UserAchievement(
+    val userLevel: Int,
     val userWardCount: Int,
     val userAnswerCount: Int,
     val userQuestionCount: Int

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/UserAchievement.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/UserAchievement.kt
@@ -1,0 +1,7 @@
+package kr.mashup.bangwidae.asked.service.levelpolicy
+
+data class UserAchievement(
+    val userWardCount: Int,
+    val userAnswerCount: Int,
+    val userQuestionCount: Int
+)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/CommentService.kt
@@ -10,7 +10,7 @@ import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.repository.CommentRepository
 import kr.mashup.bangwidae.asked.repository.PostRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.getLatitude
 import kr.mashup.bangwidae.asked.utils.getLongitude

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/post/PostService.kt
@@ -8,7 +8,7 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.post.Post
 import kr.mashup.bangwidae.asked.repository.PostRepository
 import kr.mashup.bangwidae.asked.repository.UserRepository
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import kr.mashup.bangwidae.asked.utils.getLatitude

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
@@ -10,7 +10,7 @@ import kr.mashup.bangwidae.asked.model.question.AnswerLike
 import kr.mashup.bangwidae.asked.repository.AnswerLikeRepository
 import kr.mashup.bangwidae.asked.repository.AnswerRepository
 import kr.mashup.bangwidae.asked.repository.QuestionRepository
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -7,7 +7,7 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.question.Question
 import kr.mashup.bangwidae.asked.model.question.QuestionStatus
 import kr.mashup.bangwidae.asked.repository.*
-import kr.mashup.bangwidae.asked.service.LevelPolicyService
+import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId


### PR DESCRIPTION
#131 
#132 

- 특정 레벨에 대한 정책 반환(securityconfig에서 제외하여 토큰없어도 보이게)하는 api 작성
- 사용자가 자기의 달성정보를 볼수있게 api 작성
- db에 레벨별 이미지 url 다 발라놓았음
- UserAchievement라는 vo 만들어놓음