### PR TITLE
Feature/135 Comment 익명 & UserDto에 레벨 같이 내려주기

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -14,6 +14,7 @@ data class CommentWriteRequest(
     val longitude: Double,
     @ApiModelProperty(value = "위도", example = "36.4")
     val latitude: Double,
+    @ApiModelProperty(value = "익명 여부", example = "true || null || false")
     val anonymous: Boolean?
 ) {
     fun toEntity(userId: ObjectId, postId: ObjectId): Comment {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -13,14 +13,16 @@ data class CommentWriteRequest(
     @ApiModelProperty(value = "경도", example = "136.4")
     val longitude: Double,
     @ApiModelProperty(value = "위도", example = "36.4")
-    val latitude: Double
+    val latitude: Double,
+    val anonymous: Boolean?
 ) {
     fun toEntity(userId: ObjectId, postId: ObjectId): Comment {
         return Comment(
             content = content,
             userId = userId,
             postId = postId,
-            location = GeoUtils.geoJsonPoint(longitude, latitude)
+            location = GeoUtils.geoJsonPoint(longitude, latitude),
+            anonymous = anonymous ?: false
         )
     }
 }
@@ -30,6 +32,7 @@ data class CommentEditRequest(
     val content: String,
     val longitude: Double?,
     val latitude: Double?,
+    val anonymous: Boolean?
 )
 
 data class CommentDto(
@@ -45,6 +48,8 @@ data class CommentDto(
     val userLiked: Boolean,
     @ApiModelProperty(value = "대표 주소", example = "분당구")
     val representativeAddress: String?,
+    @ApiModelProperty(value = "익명 여부", example = "true")
+    val anonymous: Boolean,
     @ApiModelProperty(value = "생성일", example = "2022-07-14T23:57:33.436")
     val createdAt: LocalDateTime?,
     @ApiModelProperty(value = "수정일", example = "2022-07-14T23:57:33.436")
@@ -54,15 +59,12 @@ data class CommentDto(
         fun from(user: User, comment: Comment, likeCount: Int, userLiked: Boolean): CommentDto {
             return CommentDto(
                 id = comment.id!!.toHexString(),
-                user = CommentWriter(
-                    id = user.id!!.toHexString(),
-                    tags = user.tags,
-                    nickname = user.nickname!!
-                ),
+                user = comment.getWriter(user),
                 content = comment.content,
                 likeCount = likeCount,
                 userLiked = userLiked,
                 representativeAddress = comment.region?.representativeAddress,
+                anonymous = comment.anonymous ?: false,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt
             )
@@ -88,11 +90,7 @@ data class CommentResultDto(
         fun from(user: User, comment: Comment): CommentResultDto {
             return CommentResultDto(
                 id = comment.id!!.toHexString(),
-                user = CommentWriter(
-                    id = user.id!!.toHexString(),
-                    tags = user.tags,
-                    nickname = user.nickname!!
-                ),
+                user = comment.getWriter(user),
                 content = comment.content,
                 representativeAddress = comment.region?.representativeAddress,
                 createdAt = comment.createdAt,
@@ -108,5 +106,18 @@ data class CommentWriter(
     @ApiModelProperty(value = "User 태그리스트", example = "[MBTI, 산책]")
     val tags: List<String> = emptyList(),
     @ApiModelProperty(value = "User 닉네임", example = "noname")
-    val nickname: String
-)
+    val nickname: String,
+    @ApiModelProperty(value = "글 작성자 프로필 이미지", example = "http://image.com")
+    val profileImageUrl: String?
+) {
+    companion object {
+        fun from(user: User) : CommentWriter {
+            return CommentWriter(
+                id = user.id!!.toHexString(),
+                tags = user.tags,
+                nickname = user.nickname!!,
+                profileImageUrl = user.profileImageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -108,15 +108,18 @@ data class CommentWriter(
     @ApiModelProperty(value = "User 닉네임", example = "noname")
     val nickname: String,
     @ApiModelProperty(value = "글 작성자 프로필 이미지", example = "http://image.com")
-    val profileImageUrl: String?
+    val profileImageUrl: String?,
+    @ApiModelProperty(value = "User 레벨", example = "13")
+    val level: Int
 ) {
     companion object {
-        fun from(user: User) : CommentWriter {
+        fun from(user: User): CommentWriter {
             return CommentWriter(
                 id = user.id!!.toHexString(),
                 tags = user.tags,
                 nickname = user.nickname!!,
-                profileImageUrl = user.profileImageUrl
+                profileImageUrl = user.profileImageUrl,
+                level = user.level
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
@@ -129,7 +129,9 @@ data class PostWriter(
     @ApiModelProperty(value = "글 작성자 닉네임", example = "sample nickname")
     val nickname: String,
     @ApiModelProperty(value = "글 작성자 프로필 이미지", example = "http://image.com")
-    val profileImageUrl: String?
+    val profileImageUrl: String?,
+    @ApiModelProperty(value = "User 레벨", example = "13")
+    val level: Int
 ) {
     companion object {
         fun from(user: User): PostWriter {
@@ -137,7 +139,8 @@ data class PostWriter(
                 id = user.id!!.toHexString(),
                 tags = user.tags,
                 nickname = user.nickname!!,
-                profileImageUrl = user.profileImageUrl
+                profileImageUrl = user.profileImageUrl,
+                level = user.level
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
@@ -247,6 +247,7 @@ data class QuestionUserDto(
     val nickname: String,
     val tags: List<String>,
     val profileImageUrl: String?,
+    val level: Int
 ) {
     companion object {
         fun from(user: QuestionUserDomain): QuestionUserDto {
@@ -255,6 +256,7 @@ data class QuestionUserDto(
                 nickname = user.nickname,
                 tags = user.tags,
                 profileImageUrl = user.profileImageUrl,
+                level = user.level
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
@@ -59,7 +59,7 @@ data class User(
     }
 
     fun getAnonymousUser(): User {
-        return this.copy(nickname = "익명", profileImageUrl = DEFAULT_PROFILE_IMAGE_URL)
+        return this.copy(nickname = "익명", profileImageUrl = DEFAULT_PROFILE_IMAGE_URL, level = 1)
     }
 
     fun levelUp(): User {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Comment.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/post/Comment.kt
@@ -1,7 +1,9 @@
 package kr.mashup.bangwidae.asked.model.post
 
 import kr.mashup.bangwidae.asked.controller.dto.CommentEditRequest
+import kr.mashup.bangwidae.asked.controller.dto.CommentWriter
 import kr.mashup.bangwidae.asked.model.Region
+import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.CreatedDate
@@ -21,6 +23,7 @@ data class Comment(
     val content: String,
     val location: GeoJsonPoint,
     val region: Region? = null,
+    val anonymous: Boolean? = false,
 
     val deleted: Boolean = false,
     @Version
@@ -33,7 +36,8 @@ data class Comment(
             this.copy(
                 content = it.content,
                 location = if (it.longitude != null && it.latitude != null)
-                    GeoUtils.geoJsonPoint(it.longitude, it.latitude) else this.location
+                    GeoUtils.geoJsonPoint(it.longitude, it.latitude) else this.location,
+                anonymous = it.anonymous ?: this.anonymous
             )
         }
     }
@@ -42,5 +46,10 @@ data class Comment(
         return this.copy(
             deleted = true,
         )
+    }
+
+    fun getWriter(user: User): CommentWriter {
+        return if (this.anonymous == true) CommentWriter.from(user.getAnonymousUser())
+        else CommentWriter.from(user)
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionDomain.kt
@@ -71,6 +71,7 @@ data class QuestionUserDomain(
     val nickname: String,
     val tags: List<String>,
     val profileImageUrl: String?,
+    val level: Int
 ) {
     companion object {
         fun from(user: User) = QuestionUserDomain(
@@ -78,6 +79,7 @@ data class QuestionUserDomain(
             nickname = user.nickname!!,
             tags = user.tags,
             profileImageUrl = user.profileImageUrl,
+            level = user.level
         )
     }
 }


### PR DESCRIPTION
- Comment 쓰고 수정할때 익명이 빠져있어서 Post 작업한 것과 같이 적용

- Post, Comment, Question, Answer 의 작성자 정보 내려줄때 레벨도 같이 내려주도록 추가
- 익명일때는 레벨 1로 내려주도록 함