### PR TITLE
Feature/114 대표와드 설정, api/me에 정보 넣기, 대표와드 정보도 넣기

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -6,6 +6,7 @@ import kr.mashup.bangwidae.asked.controller.dto.*
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.service.HeaderTextType
 import kr.mashup.bangwidae.asked.service.UserService
+import kr.mashup.bangwidae.asked.service.WardService
 import kr.mashup.bangwidae.asked.service.question.QuestionService
 import org.bson.types.ObjectId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -19,6 +20,7 @@ import springfox.documentation.annotations.ApiIgnore
 class UserController(
     private val userService: UserService,
     private val questionService: QuestionService,
+    private val wardService: WardService
 ) {
 
     @ApiOperation("ID/PW 회원가입")
@@ -34,7 +36,9 @@ class UserController(
     fun getUserInfo(
         @PathVariable userId: ObjectId
     ): ApiResponse<UserInfoDto> {
-        return ApiResponse.success(UserInfoDto.from(userService.getUserInfo(userId)))
+        val user = userService.getUserInfo(userId)
+        val representativeWard = wardService.getMyRepresentativeWard(user)
+        return ApiResponse.success(UserInfoDto.from(userService.getUserInfo(userId), representativeWard?.name))
     }
 
     @ApiOperation("유저 링크 공유")
@@ -50,7 +54,8 @@ class UserController(
             lastId = null,
             size = 2,
         )
-        return ApiResponse.success(UserLinkShareInfoDto.from(user, questions))
+        val representativeWard = wardService.getMyRepresentativeWard(user)
+        return ApiResponse.success(UserLinkShareInfoDto.from(user, questions, representativeWard?.name))
     }
 
     @ApiOperation("닉네임 설정")
@@ -72,7 +77,8 @@ class UserController(
             userService.updateProfile(
                 user,
                 updateProfileRequest.description,
-                updateProfileRequest.tags
+                updateProfileRequest.tags,
+                updateProfileRequest.representativeWardId
             )
         )
     }
@@ -94,13 +100,13 @@ class UserController(
         return ApiResponse.success(userService.updateToDefaultProfileImage(user))
     }
 
-    // 우선 principal 동작 테스트 용도
     @ApiOperation("내 정보")
     @GetMapping("/me")
     fun getMyInfo(
         @ApiIgnore @AuthenticationPrincipal user: User
-    ): ApiResponse<String> {
-        return ApiResponse.success(user.nickname!!)
+    ): ApiResponse<UserInfoDto> {
+        val representativeWard = wardService.getMyRepresentativeWard(user)
+        return ApiResponse.success(UserInfoDto.from(user, representativeWard?.name))
     }
 
     @ApiOperation("헤더 문구")

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -36,9 +36,7 @@ class UserController(
     fun getUserInfo(
         @PathVariable userId: ObjectId
     ): ApiResponse<UserInfoDto> {
-        val user = userService.getUserInfo(userId)
-        val representativeWard = wardService.getMyRepresentativeWard(user)
-        return ApiResponse.success(UserInfoDto.from(userService.getUserInfo(userId), representativeWard?.name))
+        return ApiResponse.success(userService.getUserInfo(userId))
     }
 
     @ApiOperation("유저 링크 공유")
@@ -47,7 +45,7 @@ class UserController(
         @ApiIgnore @AuthenticationPrincipal authUser: User?,
         @PathVariable userId: ObjectId
     ): ApiResponse<UserLinkShareInfoDto> {
-        val user = userService.getUserInfo(userId)
+        val user = userService.findById(userId)
         val questions = questionService.findAnswerCompleteByToUser(
             authUser = authUser,
             toUserID = userId,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/UserDto.kt
@@ -3,20 +3,23 @@ package kr.mashup.bangwidae.asked.controller.dto
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.User.Companion.DEFAULT_PROFILE_IMAGE_URL
 import kr.mashup.bangwidae.asked.service.question.QuestionDomain
+import org.bson.types.ObjectId
 
 data class UserInfoDto(
     val userId: String,
     val nickname: String?,
     val profileDescription: String?,
     val tags: List<String>,
+    val representativeWardName: String?
 ) {
     companion object {
-        fun from(user: User): UserInfoDto {
+        fun from(user: User, representativeWardName: String?): UserInfoDto {
             return UserInfoDto(
                 userId = user.id!!.toHexString(),
                 nickname = user.nickname,
                 profileDescription = user.description,
                 tags = user.tags,
+                representativeWardName = representativeWardName
             )
         }
     }
@@ -24,7 +27,7 @@ data class UserInfoDto(
 
 data class UserLinkShareInfoDto(
     val user: UserInfoDto,
-    val representativeWardName: String,
+    val representativeWardName: String?,
     val questions: List<QuestionAndAnswerDto>,
 ) {
     data class UserInfoDto(
@@ -62,9 +65,9 @@ data class UserLinkShareInfoDto(
     }
 
     companion object {
-        fun from(user: User, questions: List<QuestionDomain>) = UserLinkShareInfoDto(
+        fun from(user: User, questions: List<QuestionDomain>, representativeWardName: String?) = UserLinkShareInfoDto(
             user = UserInfoDto.from(user),
-            representativeWardName = "todo - 우리집",
+            representativeWardName = representativeWardName,
             questions = questions.map { QuestionAndAnswerDto.from(it) },
         )
     }
@@ -87,6 +90,7 @@ data class UpdateNicknameRequest(
 data class UpdateProfileRequest(
     val description: String,
     val tags: List<String>,
+    val representativeWardId: ObjectId?
 )
 
 data class UserSettingsDto(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/Ward.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/Ward.kt
@@ -1,6 +1,5 @@
 package kr.mashup.bangwidae.asked.controller.dto
 
-import io.swagger.annotations.ApiModelProperty
 import kr.mashup.bangwidae.asked.model.Ward
 import kr.mashup.bangwidae.asked.utils.getLatitude
 import kr.mashup.bangwidae.asked.utils.getLongitude
@@ -12,7 +11,8 @@ data class WardDto(
     val longitude: Double,
     val latitude: Double,
     val createdAt: LocalDateTime?,
-    val remainDays: String
+    val remainDays: String,
+    val isRepresentative: Boolean
 ) {
     companion object {
         fun from(ward: Ward): WardDto {
@@ -22,7 +22,8 @@ data class WardDto(
                 longitude = ward.location.getLongitude(),
                 latitude = ward.location.getLatitude(),
                 createdAt = ward.createdAt,
-                remainDays = ward.getDDays()
+                remainDays = ward.getDDays(),
+                isRepresentative = ward.isRepresentative ?: false
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/User.kt
@@ -73,7 +73,7 @@ data class User(
 
     companion object {
         const val DEFAULT_PROFILE_IMAGE_URL: String =
-            "https://dori-dori-bucket.kr.object.ncloudstorage.com/profile/da26c773-30f4-473e-989b-e2f3fdf825ff%E1%84%80%E1%85%B5%E1%84%87%E1%85%A9%E1%86%AB%20%E1%84%91%E1%85%B3%E1%84%85%E1%85%A9%E1%84%91%E1%85%B5%E1%86%AF.png"
+            "https://dori-dori-bucket.kr.object.ncloudstorage.com/PROFILE/DEFAULT_IMAGE.png"
 
         fun createBasicUser(email: String, password: String): User {
             return User(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/Ward.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/Ward.kt
@@ -21,6 +21,7 @@ data class Ward(
     val expiredAt: LocalDateTime,
     @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
     val location: GeoJsonPoint,
+    val isRepresentative: Boolean? = false,
     @Version var version: Int? = null,
     @CreatedDate var createdAt: LocalDateTime? = null,
     @LastModifiedDate var updatedAt: LocalDateTime? = null

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/WardRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/WardRepository.kt
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
-interface WardRepository: MongoRepository<Ward, ObjectId> {
+interface WardRepository : MongoRepository<Ward, ObjectId> {
     fun countAllByUserId(userId: ObjectId): Int
     fun findAllByUserIdAndExpiredAtAfter(userId: ObjectId, expiredAt: LocalDateTime): List<Ward>
+    fun findWardByUserIdAndExpiredAtAfterAndIsRepresentativeTrue(userId: ObjectId, expiredAt: LocalDateTime): Ward?
+    fun findWardByIdAndExpiredAtAfter(wardId: ObjectId, expiredAt: LocalDateTime): Ward?
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -16,6 +16,7 @@ import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(
@@ -24,7 +25,8 @@ class UserService(
     private val certMailService: CertMailService,
     private val passwordService: PasswordService,
     private val questionService: QuestionService,
-    private val s3ImageUploader: S3ImageUploader
+    private val s3ImageUploader: S3ImageUploader,
+    private val wardService: WardService
 ) {
 
     fun joinUser(joinUserRequest: JoinUserRequest): JoinUserResponse {
@@ -76,10 +78,10 @@ class UserService(
         return true
     }
 
-    fun updateProfile(user: User, description: String, tags: List<String>): Boolean {
-        userRepository.save(
-            user.updateProfile(description, tags)
-        )
+    @Transactional
+    fun updateProfile(user: User, description: String, tags: List<String>, representativeWardId: ObjectId?): Boolean {
+        userRepository.save(user.updateProfile(description, tags))
+        wardService.updateRepresentativeWard(user, representativeWardId)
         return true
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -5,6 +5,7 @@ import kr.mashup.bangwidae.asked.config.auth.password.PasswordService
 import kr.mashup.bangwidae.asked.controller.dto.EditUserSettingsRequest
 import kr.mashup.bangwidae.asked.controller.dto.JoinUserRequest
 import kr.mashup.bangwidae.asked.controller.dto.JoinUserResponse
+import kr.mashup.bangwidae.asked.controller.dto.UserInfoDto
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.external.aws.S3ImageUploader
@@ -55,9 +56,11 @@ class UserService(
         )
     }
 
-    fun getUserInfo(userId: ObjectId): User {
-        return userRepository.findById(userId)
+    fun getUserInfo(userId: ObjectId): UserInfoDto {
+        val user = userRepository.findById(userId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+        val representativeWard = wardService.getMyRepresentativeWard(user)
+        return UserInfoDto.from(user, representativeWard?.name)
     }
 
     fun getUserHeaderText(user: User, type: HeaderTextType): String {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
@@ -40,6 +40,10 @@ class WardService(
         return wardRepository.findAllByUserIdAndExpiredAtAfter(user.id!!, LocalDateTime.now())
     }
 
+    fun getMyRepresentativeWard(user: User): Ward? {
+        return getMyWards(user).firstOrNull { it.isRepresentative == true }
+    }
+
     fun deleteWard(user: User, wardId: ObjectId) {
         val ward = wardRepository.findById(wardId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.WARD_NOT_FOUND) }
@@ -61,5 +65,9 @@ class WardService(
         return ward.extendPeriod(period).let {
             wardRepository.save(it)
         }
+    }
+
+    fun updateRepresentativeWard(user: User, wardId: ObjectId?) {
+        wardRepository.saveAll(getMyWards(user).map {it.copy(isRepresentative = (it.id == wardId))})
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/WardService.kt
@@ -40,10 +40,6 @@ class WardService(
         return wardRepository.findAllByUserIdAndExpiredAtAfter(user.id!!, LocalDateTime.now())
     }
 
-    fun getMyRepresentativeWard(user: User): Ward? {
-        return getMyWards(user).firstOrNull { it.isRepresentative == true }
-    }
-
     fun deleteWard(user: User, wardId: ObjectId) {
         val ward = wardRepository.findById(wardId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.WARD_NOT_FOUND) }
@@ -51,7 +47,7 @@ class WardService(
         if (ward.userId != user.id!!) {
             throw DoriDoriException.of(DoriDoriExceptionType.NOT_ALLOWED_TO_ACCESS)
         }
-        
+
         wardRepository.delete(ward)
     }
 
@@ -67,7 +63,16 @@ class WardService(
         }
     }
 
-    fun updateRepresentativeWard(user: User, wardId: ObjectId?) {
-        wardRepository.saveAll(getMyWards(user).map {it.copy(isRepresentative = (it.id == wardId))})
+    fun getMyRepresentativeWard(user: User): Ward? {
+        return wardRepository.findWardByUserIdAndExpiredAtAfterAndIsRepresentativeTrue(user.id!!, LocalDateTime.now())
+    }
+
+    fun updateRepresentativeWard(user: User, representativeWardId: ObjectId?) {
+        getMyRepresentativeWard(user)?.let { wardRepository.save(it.copy(isRepresentative = false)) }
+        if (representativeWardId != null) {
+            wardRepository.findWardByIdAndExpiredAtAfter(representativeWardId, LocalDateTime.now())?.let {
+                wardRepository.save(it.copy(isRepresentative = true))
+            }
+        }
     }
 }


### PR DESCRIPTION
#142 
#114 
#130 

- 프로필 업데이트할때 대표 와드 id 넣어서 업데이트 하도록.
- representativeWardId가 null로 들어온다는거는 해당없음 체크한 것이다.
- representativeWard가 없을때는 representativeWardName 을 Null로 나간다
- /api/me에 유저정보 나가도록 업데이트
- default image url 심플하게 해달라는거 반영