### PR TITLE
Notification Event Publish 로직 구현

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/AskedApplication.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/AskedApplication.kt
@@ -3,7 +3,9 @@ package kr.mashup.bangwidae.asked
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.scheduling.annotation.EnableAsync
 
+@EnableAsync
 @EnableFeignClients
 @SpringBootApplication
 class AskedApplication

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/Event.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/Event.kt
@@ -1,0 +1,19 @@
+package kr.mashup.bangwidae.asked.service.event
+
+import org.bson.types.ObjectId
+
+data class QuestionWriteEvent(
+    val questionId: ObjectId,
+) : NotificationEvent
+
+data class AnswerWriteEvent(
+    val answerId: ObjectId,
+) : NotificationEvent
+
+data class CommentWriteEvent(
+    val commentId: ObjectId,
+) : NotificationEvent
+
+data class LevelUpEvent(
+    val userId: ObjectId,
+) : NotificationEvent

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/NotificationEvent.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/NotificationEvent.kt
@@ -1,9 +1,9 @@
 package kr.mashup.bangwidae.asked.service.event
 
 import kr.mashup.bangwidae.asked.service.notification.NotificationService
+import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import org.springframework.transaction.event.TransactionalEventListener
 
 sealed interface NotificationEvent
 
@@ -12,7 +12,7 @@ class NotificationEventHandler(
     private val notificationService: NotificationService,
 ) {
     @Async
-    @TransactionalEventListener
+    @EventListener
     fun notificationEventListener(event: NotificationEvent) {
         notificationService.generate(event)
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/NotificationEvent.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/event/NotificationEvent.kt
@@ -1,0 +1,19 @@
+package kr.mashup.bangwidae.asked.service.event
+
+import kr.mashup.bangwidae.asked.service.notification.NotificationService
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionalEventListener
+
+sealed interface NotificationEvent
+
+@Component
+class NotificationEventHandler(
+    private val notificationService: NotificationService,
+) {
+    @Async
+    @TransactionalEventListener
+    fun notificationEventListener(event: NotificationEvent) {
+        notificationService.generate(event)
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/LevelPolicyService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/levelpolicy/LevelPolicyService.kt
@@ -5,6 +5,8 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.LevelPolicy
 import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.repository.*
+import kr.mashup.bangwidae.asked.service.event.LevelUpEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,6 +18,7 @@ class LevelPolicyService(
     private val commentRepository: CommentRepository,
     private val postRepository: PostRepository,
     private val levelPolicyRepository: LevelPolicyRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
 
     fun levelUpIfConditionSatisfied(user: User) {
@@ -31,6 +34,7 @@ class LevelPolicyService(
 
         if (satisfiedLevelUp) {
             userRepository.save(user.levelUp())
+            applicationEventPublisher.publishEvent(LevelUpEvent(user.id!!))
         }
     }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/LevelUpNotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/LevelUpNotificationGenerator.kt
@@ -4,6 +4,8 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.Notification
 import kr.mashup.bangwidae.asked.service.UserService
+import kr.mashup.bangwidae.asked.service.event.LevelUpEvent
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
 import org.springframework.stereotype.Component
 
 @Component
@@ -11,13 +13,13 @@ class LevelUpNotificationGenerator(
     private val userService: UserService,
     private val urlSchemeProperties: UrlSchemeProperties,
 ) : NotificationGenerator {
-    override fun support(spec: NotificationSpec): Boolean {
-        return spec is LevelUpNotificationSpec
+    override fun support(event: NotificationEvent): Boolean {
+        return event is LevelUpEvent
     }
 
-    override fun generate(spec: NotificationSpec): List<Notification> {
-        if (spec is LevelUpNotificationSpec) {
-            val user = userService.findById(spec.userId)
+    override fun generate(event: NotificationEvent): List<Notification> {
+        if (event is LevelUpEvent) {
+            val user = userService.findById(event.userId)
 
             return listOf(
                 Notification(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationGenerator.kt
@@ -1,27 +1,9 @@
 package kr.mashup.bangwidae.asked.service.notification
 
 import kr.mashup.bangwidae.asked.model.Notification
-import org.bson.types.ObjectId
-
-sealed interface NotificationSpec
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
 
 interface NotificationGenerator {
-    fun support(spec: NotificationSpec): Boolean
-    fun generate(spec: NotificationSpec): List<Notification>
+    fun support(event: NotificationEvent): Boolean
+    fun generate(event: NotificationEvent): List<Notification>
 }
-
-data class QuestionAnsweredNotificationSpec(
-    val answerId: ObjectId,
-) : NotificationSpec
-
-data class QuestionReceivedNotificationSpec(
-    val questionId: ObjectId,
-) : NotificationSpec
-
-data class PostCommentedNotificationSpec(
-    val commentId: ObjectId,
-) : NotificationSpec
-
-data class LevelUpNotificationSpec(
-    val userId: ObjectId,
-) : NotificationSpec

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationService.kt
@@ -2,6 +2,7 @@ package kr.mashup.bangwidae.asked.service.notification
 
 import kr.mashup.bangwidae.asked.model.Notification
 import kr.mashup.bangwidae.asked.repository.NotificationRepository
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,11 +10,11 @@ class NotificationService(
     private val notificationRepository: NotificationRepository,
     private val notificationGenerators: List<NotificationGenerator>,
 ) {
-    fun generate(spec: NotificationSpec): List<Notification> {
-        val notification = notificationGenerators
-            .first { it.support(spec) }
-            .generate(spec)
+    fun generate(event: NotificationEvent): List<Notification> {
+        val notifications = notificationGenerators
+            .first { it.support(event) }
+            .generate(event)
 
-        return notificationRepository.saveAll(notification)
+        return notificationRepository.saveAll(notifications)
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/PostCommentedNotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/PostCommentedNotificationGenerator.kt
@@ -27,9 +27,10 @@ class PostCommentedNotificationGenerator(
     override fun generate(event: NotificationEvent): List<Notification> {
         if (event is CommentWriteEvent) {
             val comment = commentService.findById(event.commentId)
+            val post = postService.findById(comment.postId)
+            if (comment.userId == post.userId) return emptyList()
             val commentUserNickname =
                 if (comment.anonymous == true) "익명" else userService.findById(comment.userId).nickname
-            val post = postService.findById(comment.postId)
 
             return listOf(
                 Notification(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/PostCommentedNotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/PostCommentedNotificationGenerator.kt
@@ -4,6 +4,8 @@ import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.Notification
 import kr.mashup.bangwidae.asked.service.UserService
+import kr.mashup.bangwidae.asked.service.event.CommentWriteEvent
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
 import kr.mashup.bangwidae.asked.service.post.CommentService
 import kr.mashup.bangwidae.asked.service.post.PostService
 import kr.mashup.bangwidae.asked.utils.StringUtils
@@ -18,13 +20,13 @@ class PostCommentedNotificationGenerator(
     private val userService: UserService,
     private val urlSchemeProperties: UrlSchemeProperties,
 ) : NotificationGenerator {
-    override fun support(spec: NotificationSpec): Boolean {
-        return spec is PostCommentedNotificationSpec
+    override fun support(event: NotificationEvent): Boolean {
+        return event is CommentWriteEvent
     }
 
-    override fun generate(spec: NotificationSpec): List<Notification> {
-        if (spec is PostCommentedNotificationSpec) {
-            val comment = commentService.findById(spec.commentId)
+    override fun generate(event: NotificationEvent): List<Notification> {
+        if (event is CommentWriteEvent) {
+            val comment = commentService.findById(event.commentId)
             val commentUserNickname =
                 if (comment.anonymous == true) "익명" else userService.findById(comment.userId).nickname
             val post = postService.findById(comment.postId)

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/QuestionAnsweredNotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/QuestionAnsweredNotificationGenerator.kt
@@ -3,6 +3,8 @@ package kr.mashup.bangwidae.asked.service.notification
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.Notification
+import kr.mashup.bangwidae.asked.service.event.AnswerWriteEvent
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
 import kr.mashup.bangwidae.asked.service.question.AnswerService
 import kr.mashup.bangwidae.asked.service.question.QuestionService
 import kr.mashup.bangwidae.asked.utils.StringUtils
@@ -16,13 +18,13 @@ class QuestionAnsweredNotificationGenerator(
     private val answerService: AnswerService,
     private val urlSchemeProperties: UrlSchemeProperties,
 ) : NotificationGenerator {
-    override fun support(spec: NotificationSpec): Boolean {
-        return spec is QuestionAnsweredNotificationSpec
+    override fun support(event: NotificationEvent): Boolean {
+        return event is AnswerWriteEvent
     }
 
-    override fun generate(spec: NotificationSpec): List<Notification> {
-        if (spec is QuestionAnsweredNotificationSpec) {
-            val answer = answerService.findById(spec.answerId)
+    override fun generate(event: NotificationEvent): List<Notification> {
+        if (event is AnswerWriteEvent) {
+            val answer = answerService.findById(event.answerId)
             val question = questionService.findDetailById(null, answer.questionId)
 
             return listOf(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/QuestionReceivedNotificationGenerator.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/QuestionReceivedNotificationGenerator.kt
@@ -3,6 +3,8 @@ package kr.mashup.bangwidae.asked.service.notification
 import kr.mashup.bangwidae.asked.exception.DoriDoriException
 import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.Notification
+import kr.mashup.bangwidae.asked.service.event.NotificationEvent
+import kr.mashup.bangwidae.asked.service.event.QuestionWriteEvent
 import kr.mashup.bangwidae.asked.service.question.QuestionService
 import kr.mashup.bangwidae.asked.utils.StringUtils
 import kr.mashup.bangwidae.asked.utils.UrlSchemeParameter
@@ -14,13 +16,13 @@ class QuestionReceivedNotificationGenerator(
     private val questionService: QuestionService,
     private val urlSchemeProperties: UrlSchemeProperties,
 ) : NotificationGenerator {
-    override fun support(spec: NotificationSpec): Boolean {
-        return spec is QuestionReceivedNotificationSpec
+    override fun support(event: NotificationEvent): Boolean {
+        return event is QuestionWriteEvent
     }
 
-    override fun generate(spec: NotificationSpec): List<Notification> {
-        if (spec is QuestionReceivedNotificationSpec) {
-            val question = questionService.findDetailById(null, spec.questionId)
+    override fun generate(event: NotificationEvent): List<Notification> {
+        if (event is QuestionWriteEvent) {
+            val question = questionService.findDetailById(null, event.questionId)
 
             return listOf(
                 Notification(

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/AnswerService.kt
@@ -10,10 +10,12 @@ import kr.mashup.bangwidae.asked.model.question.AnswerLike
 import kr.mashup.bangwidae.asked.repository.AnswerLikeRepository
 import kr.mashup.bangwidae.asked.repository.AnswerRepository
 import kr.mashup.bangwidae.asked.repository.QuestionRepository
+import kr.mashup.bangwidae.asked.service.event.AnswerWriteEvent
 import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,6 +28,7 @@ class AnswerService(
     private val answerRepository: AnswerRepository,
     private val answerLikeRepository: AnswerLikeRepository,
     private val questionRepository: QuestionRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : WithQuestionAuthorityValidator, WithAnswerAuthorityValidator {
     fun findById(answerId: ObjectId): Answer {
         return answerRepository.findByIdAndDeletedFalse(answerId)
@@ -58,6 +61,8 @@ class AnswerService(
                 )
             ).also {
                 levelPolicyService.levelUpIfConditionSatisfied(user)
+            }.also {
+                applicationEventPublisher.publishEvent(AnswerWriteEvent(it.id!!))
             }
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/question/QuestionService.kt
@@ -7,10 +7,12 @@ import kr.mashup.bangwidae.asked.model.User
 import kr.mashup.bangwidae.asked.model.question.Question
 import kr.mashup.bangwidae.asked.model.question.QuestionStatus
 import kr.mashup.bangwidae.asked.repository.*
+import kr.mashup.bangwidae.asked.service.event.QuestionWriteEvent
 import kr.mashup.bangwidae.asked.service.levelpolicy.LevelPolicyService
 import kr.mashup.bangwidae.asked.service.place.PlaceService
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -26,6 +28,7 @@ class QuestionService(
     private val answerLikeRepository: AnswerLikeRepository,
     private val answerLikeAggregator: AnswerLikeAggregator,
     private val userRepository: UserRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : WithQuestionAuthorityValidator {
     private fun findById(questionId: ObjectId): Question {
         return questionRepository.findByIdAndDeletedFalse(questionId)
@@ -150,6 +153,8 @@ class QuestionService(
                 )
             ).also {
                 levelPolicyService.levelUpIfConditionSatisfied(user)
+            }.also {
+                applicationEventPublisher.publishEvent(QuestionWriteEvent(it.id!!))
             }
         }
     }


### PR DESCRIPTION
## 설명
- ApplicationEventPublisher로 Post, Answer, Comment 작성 이벤트를 발생시키고, Listener에서 받아서 Notification을 생성하도록 구현했습니다.
- 외부 시스템이랑 연동한게 아니라 단일 애플리케이션 내에서 강결합만 끊은거라.. 어느 정도 한계는 존재하지만 구조 잡아놓으면 나중에 메세지 시스템 도입할 때 어렵지 않을 것 같아서 적용해 봤습니다.
- NotificationSpec을 Event로 이름 변경하고 패키지 구조도 변경했습니다.

리뷰 대환영~~