### PR TITLE
알림 리스트 페이징, 미확인 알림 개수 조회, 알림 읽음 처리 API

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/NotificationController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/NotificationController.kt
@@ -1,0 +1,58 @@
+package kr.mashup.bangwidae.asked.controller
+
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import kr.mashup.bangwidae.asked.controller.dto.ApiResponse
+import kr.mashup.bangwidae.asked.controller.dto.CursorResult
+import kr.mashup.bangwidae.asked.controller.dto.NotificationDto
+import kr.mashup.bangwidae.asked.model.document.User
+import kr.mashup.bangwidae.asked.service.notification.NotificationService
+import org.bson.types.ObjectId
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import springfox.documentation.annotations.ApiIgnore
+
+@Api(tags = ["알림 컨트롤러"])
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationController(
+    private val notificationService: NotificationService,
+) {
+    @ApiOperation("알림 페이징 조회")
+    @GetMapping
+    fun getMyNotifications(
+        @ApiIgnore @AuthenticationPrincipal user: User,
+        @RequestParam size: Int,
+        @RequestParam(required = false) lastId: ObjectId?,
+    ): ApiResponse<CursorResult<NotificationDto>> {
+        return notificationService.findByUser(
+            user = user,
+            lastId = lastId,
+            size = size + 1,
+        ).map { NotificationDto.from(it) }
+            .let { CursorResult.from(it, size) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @ApiOperation("미확인 알림 개수 조회")
+    @GetMapping("/unread-count")
+    fun getMyUnreadNotificationsCount(
+        @ApiIgnore @AuthenticationPrincipal user: User,
+    ): ApiResponse<Long> {
+        return notificationService.countUnreadByUser(
+            user = user,
+        ).let { ApiResponse.success(it) }
+    }
+
+    @ApiOperation("알림 읽음 처리")
+    @PostMapping("/{notificationId}/read")
+    fun readNotification(
+        @ApiIgnore @AuthenticationPrincipal user: User,
+        @PathVariable notificationId: ObjectId,
+    ): ApiResponse<ObjectId> {
+        return notificationService.read(
+            notificationId = notificationId,
+            user = user,
+        ).let { ApiResponse.success(it.id!!) }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/NotificationDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/NotificationDto.kt
@@ -1,0 +1,30 @@
+package kr.mashup.bangwidae.asked.controller.dto
+
+import kr.mashup.bangwidae.asked.model.document.Notification
+import kr.mashup.bangwidae.asked.service.notification.NotificationType
+import org.bson.types.ObjectId
+import java.time.LocalDateTime
+
+data class NotificationDto(
+    val id: ObjectId,
+    val type: NotificationType,
+    val title: String,
+    val content: String,
+    val read: Boolean,
+    val urlScheme: String,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notification: Notification): NotificationDto {
+            return NotificationDto(
+                id = notification.id!!,
+                type = notification.type,
+                title = notification.title,
+                content = notification.content,
+                read = notification.read,
+                urlScheme = notification.urlScheme,
+                createdAt = notification.createdAt!!,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/document/Notification.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/document/Notification.kt
@@ -22,4 +22,8 @@ data class Notification(
     @Version var version: Int? = null,
     @CreatedDate var createdAt: LocalDateTime? = null,
     @LastModifiedDate var updatedAt: LocalDateTime? = null
-)
+) {
+    fun read(): Notification {
+        return this.copy(read = true)
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/NotificationRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/NotificationRepository.kt
@@ -2,6 +2,15 @@ package kr.mashup.bangwidae.asked.repository
 
 import kr.mashup.bangwidae.asked.model.document.Notification
 import org.bson.types.ObjectId
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface NotificationRepository: MongoRepository<Notification, ObjectId>
+interface NotificationRepository : MongoRepository<Notification, ObjectId> {
+    fun findByUserIdAndIdBeforeOrderByCreatedAtDesc(
+        userId: ObjectId,
+        lastId: ObjectId,
+        pageRequest: PageRequest,
+    ): List<Notification>
+
+    fun countByUserIdAndReadFalse(userId: ObjectId): Long
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/notification/NotificationService.kt
@@ -1,8 +1,14 @@
 package kr.mashup.bangwidae.asked.service.notification
 
+import kr.mashup.bangwidae.asked.exception.DoriDoriException
+import kr.mashup.bangwidae.asked.exception.DoriDoriExceptionType
 import kr.mashup.bangwidae.asked.model.document.Notification
+import kr.mashup.bangwidae.asked.model.document.User
 import kr.mashup.bangwidae.asked.repository.NotificationRepository
 import kr.mashup.bangwidae.asked.service.event.NotificationEvent
+import org.bson.types.ObjectId
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,5 +22,28 @@ class NotificationService(
             .generate(event)
 
         return notificationRepository.saveAll(notifications)
+    }
+
+    fun findByUser(user: User, lastId: ObjectId?, size: Int): List<Notification> {
+        return notificationRepository.findByUserIdAndIdBeforeOrderByCreatedAtDesc(
+            userId = user.id!!,
+            lastId = lastId ?: ObjectId(),
+            pageRequest = PageRequest.of(0, size),
+        )
+    }
+
+    fun countUnreadByUser(user: User): Long {
+        return notificationRepository.countByUserIdAndReadFalse(user.id!!)
+    }
+
+    fun read(notificationId: ObjectId, user: User): Notification {
+        val notification = notificationRepository.findByIdOrNull(notificationId)
+            ?: throw DoriDoriException.of(DoriDoriExceptionType.NOT_EXIST)
+
+        if (notification.userId != user.id) {
+            throw DoriDoriException.of(DoriDoriExceptionType.NOT_ALLOWED_TO_ACCESS)
+        }
+
+        return notificationRepository.save(notification.read())
     }
 }


### PR DESCRIPTION
## 설명
- 알림 리스트 페이징, 미확인 알림 개수 조회, 알림 읽음 처리 API
- 읽음 상태는 기획 상 없긴 한데.. 긴단하게 할 수 있을 것 같아서 해봤습니다..! (미확인 알림 카운트 API + 읽음 처리 API)