### PR TITLE
Feature/179 유저 삭제

### DIFF
--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/UserController.kt
@@ -225,6 +225,7 @@ class UserController(
     fun leaveUser(
         @ApiIgnore @AuthenticationPrincipal user: User
     ): ApiResponse<Boolean> {
-        return ApiResponse.success(true)
+        return userService.delete(user)
+            .let { ApiResponse.success(true) }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -3,7 +3,6 @@ package kr.mashup.bangwidae.asked.controller.dto
 import io.swagger.annotations.ApiModelProperty
 import kr.mashup.bangwidae.asked.model.document.post.Comment
 import kr.mashup.bangwidae.asked.model.domain.CommentDomain
-import kr.mashup.bangwidae.asked.model.domain.CommentUserDomain
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
 import java.time.LocalDateTime
@@ -39,7 +38,7 @@ data class CommentEditRequest(
 
 data class CommentDto(
     val id: String,
-    val user: CommentWriter,
+    val user: WriterUserDto,
     val content: String,
     val likeCount: Int,
     val userLiked: Boolean,
@@ -52,34 +51,14 @@ data class CommentDto(
         fun from(comment: CommentDomain): CommentDto {
             return CommentDto(
                 id = comment.id.toHexString(),
-                user = CommentWriter.from(comment.user),
+                user = WriterUserDto.from(comment.user),
                 content = comment.content,
                 likeCount = comment.likeCount,
                 userLiked = comment.userLiked,
-                representativeAddress = comment.representativeAddress?: "",
+                representativeAddress = comment.representativeAddress,
                 anonymous = comment.anonymous,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt
-            )
-        }
-    }
-}
-
-data class CommentWriter(
-    val id: String,
-    val tags: List<String> = emptyList(),
-    val nickname: String,
-    val profileImageUrl: String?,
-    val level: Int
-) {
-    companion object {
-        fun from(user: CommentUserDomain): CommentWriter {
-            return CommentWriter(
-                id = user.id.toHexString(),
-                tags = user.tags,
-                nickname = user.nickname,
-                profileImageUrl = user.profileImageUrl,
-                level = user.level
             )
         }
     }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/CommentDto.kt
@@ -55,7 +55,7 @@ data class CommentDto(
                 content = comment.content,
                 likeCount = comment.likeCount,
                 userLiked = comment.userLiked,
-                representativeAddress = comment.representativeAddress,
+                representativeAddress = comment.representativeAddress ?: "",
                 anonymous = comment.anonymous,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
@@ -31,7 +31,7 @@ data class PostDto(
                 commentCount = post.commentCount,
                 longitude = post.longitude,
                 latitude = post.latitude,
-                representativeAddress = post.representativeAddress,
+                representativeAddress = post.representativeAddress ?: "",
                 anonymous = post.anonymous,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/PostDto.kt
@@ -2,14 +2,13 @@ package kr.mashup.bangwidae.asked.controller.dto
 
 import kr.mashup.bangwidae.asked.model.document.post.Post
 import kr.mashup.bangwidae.asked.model.domain.PostDomain
-import kr.mashup.bangwidae.asked.model.domain.PostUserDomain
 import kr.mashup.bangwidae.asked.utils.GeoUtils
 import org.bson.types.ObjectId
 import java.time.LocalDateTime
 
 data class PostDto(
     val id: String,
-    val user: PostWriter,
+    val user: WriterUserDto,
     val content: String = "",
     val likeCount: Int,
     val commentCount: Int,
@@ -25,14 +24,14 @@ data class PostDto(
         fun from(post: PostDomain) =
             PostDto(
                 id = post.id.toHexString(),
-                user = PostWriter.from(post.user),
+                user = WriterUserDto.from(post.user),
                 content = post.content,
                 likeCount = post.likeCount,
                 userLiked = post.userLiked,
                 commentCount = post.commentCount,
                 longitude = post.longitude,
                 latitude = post.latitude,
-                representativeAddress = post.representativeAddress?: "",
+                representativeAddress = post.representativeAddress,
                 anonymous = post.anonymous,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt,
@@ -62,23 +61,3 @@ data class PostEditRequest(
     val latitude: Double?,
     val anonymous: Boolean?
 )
-
-data class PostWriter(
-    val id: String,
-    val tags: List<String> = emptyList(),
-    val nickname: String,
-    val profileImageUrl: String?,
-    val level: Int
-) {
-    companion object {
-        fun from(user: PostUserDomain): PostWriter {
-            return PostWriter(
-                id = user.id.toHexString(),
-                tags = user.tags,
-                nickname = user.nickname,
-                profileImageUrl = user.profileImageUrl,
-                level = user.level
-            )
-        }
-    }
-}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
@@ -61,7 +61,7 @@ data class QuestionDetailDto(
                 return AnswerDto(
                     id = answer.id.toHexString(),
                     content = answer.content,
-                    representativeAddress = answer.representativeAddress,
+                    representativeAddress = answer.representativeAddress ?: "",
                     user = WriterUserDto.from(answer.user),
                     likeCount = answer.likeCount,
                     userLiked = answer.userLiked,
@@ -76,7 +76,7 @@ data class QuestionDetailDto(
             return QuestionDetailDto(
                 id = question.id.toHexString(),
                 content = question.content,
-                representativeAddress = question.representativeAddress,
+                representativeAddress = question.representativeAddress ?: "",
                 anonymous = question.anonymous,
                 fromUser = WriterUserDto.from(question.fromUser),
                 toUser = WriterUserDto.from(question.toUser),
@@ -106,7 +106,7 @@ data class AnsweredQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress,
+                    representativeAddress = question.representativeAddress ?: "",
                     anonymous = question.anonymous,
                     fromUser = WriterUserDto.from(question.fromUser),
                     toUser = WriterUserDto.from(question.toUser),
@@ -131,7 +131,7 @@ data class AnsweredQuestionsDto(
                 return AnswerDto(
                     id = answer.id.toHexString(),
                     content = answer.content,
-                    representativeAddress = answer.representativeAddress,
+                    representativeAddress = answer.representativeAddress ?: "",
                     user = WriterUserDto.from(answer.user),
                     likeCount = answer.likeCount,
                     userLiked = answer.userLiked,
@@ -174,7 +174,7 @@ data class ReceivedQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress,
+                    representativeAddress = question.representativeAddress ?: "",
                     anonymous = question.anonymous,
                     fromUser = WriterUserDto.from(question.fromUser),
                     toUser = WriterUserDto.from(question.toUser),
@@ -217,7 +217,7 @@ data class AskedQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress,
+                    representativeAddress = question.representativeAddress ?: "",
                     anonymous = question.anonymous,
                     fromUser = WriterUserDto.from(question.fromUser),
                     toUser = WriterUserDto.from(question.toUser),

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/QuestionDto.kt
@@ -3,7 +3,6 @@ package kr.mashup.bangwidae.asked.controller.dto
 import io.swagger.annotations.ApiModelProperty
 import kr.mashup.bangwidae.asked.model.domain.AnswerDomain
 import kr.mashup.bangwidae.asked.model.domain.QuestionDomain
-import kr.mashup.bangwidae.asked.model.domain.QuestionUserDomain
 import org.bson.types.ObjectId
 import java.time.LocalDateTime
 import kotlin.math.min
@@ -43,8 +42,8 @@ data class QuestionDetailDto(
     val content: String,
     val representativeAddress: String,
     val anonymous: Boolean,
-    val fromUser: QuestionUserDto,
-    val toUser: QuestionUserDto,
+    val fromUser: WriterUserDto,
+    val toUser: WriterUserDto,
     val answer: AnswerDto?,
     val createdAt: LocalDateTime,
 ) {
@@ -52,7 +51,7 @@ data class QuestionDetailDto(
         val id: String,
         val content: String,
         val representativeAddress: String,
-        val user: QuestionUserDto,
+        val user: WriterUserDto,
         val likeCount: Long,
         val userLiked: Boolean,
         val createdAt: LocalDateTime,
@@ -62,8 +61,8 @@ data class QuestionDetailDto(
                 return AnswerDto(
                     id = answer.id.toHexString(),
                     content = answer.content,
-                    representativeAddress = answer.representativeAddress?: "",
-                    user = QuestionUserDto.from(answer.user),
+                    representativeAddress = answer.representativeAddress,
+                    user = WriterUserDto.from(answer.user),
                     likeCount = answer.likeCount,
                     userLiked = answer.userLiked,
                     createdAt = answer.createdAt,
@@ -77,10 +76,10 @@ data class QuestionDetailDto(
             return QuestionDetailDto(
                 id = question.id.toHexString(),
                 content = question.content,
-                representativeAddress = question.representativeAddress?: "",
+                representativeAddress = question.representativeAddress,
                 anonymous = question.anonymous,
-                fromUser = QuestionUserDto.from(question.fromUser),
-                toUser = QuestionUserDto.from(question.toUser),
+                fromUser = WriterUserDto.from(question.fromUser),
+                toUser = WriterUserDto.from(question.toUser),
                 answer = question.answer?.let { AnswerDto.from(question.answer) },
                 createdAt = question.createdAt,
             )
@@ -97,8 +96,8 @@ data class AnsweredQuestionsDto(
         val content: String,
         val representativeAddress: String,
         val anonymous: Boolean,
-        val fromUser: QuestionUserDto,
-        val toUser: QuestionUserDto,
+        val fromUser: WriterUserDto,
+        val toUser: WriterUserDto,
         val answer: AnswerDto,
         val createdAt: LocalDateTime,
     ) {
@@ -107,10 +106,10 @@ data class AnsweredQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress?: "",
+                    representativeAddress = question.representativeAddress,
                     anonymous = question.anonymous,
-                    fromUser = QuestionUserDto.from(question.fromUser),
-                    toUser = QuestionUserDto.from(question.toUser),
+                    fromUser = WriterUserDto.from(question.fromUser),
+                    toUser = WriterUserDto.from(question.toUser),
                     answer = AnswerDto.from(question.answer!!),
                     createdAt = question.createdAt,
                 )
@@ -122,7 +121,7 @@ data class AnsweredQuestionsDto(
         val id: String,
         val content: String,
         val representativeAddress: String,
-        val user: QuestionUserDto,
+        val user: WriterUserDto,
         val likeCount: Long,
         val userLiked: Boolean,
         val createdAt: LocalDateTime,
@@ -132,8 +131,8 @@ data class AnsweredQuestionsDto(
                 return AnswerDto(
                     id = answer.id.toHexString(),
                     content = answer.content,
-                    representativeAddress = answer.representativeAddress?: "",
-                    user = QuestionUserDto.from(answer.user),
+                    representativeAddress = answer.representativeAddress,
+                    user = WriterUserDto.from(answer.user),
                     likeCount = answer.likeCount,
                     userLiked = answer.userLiked,
                     createdAt = answer.createdAt,
@@ -166,8 +165,8 @@ data class ReceivedQuestionsDto(
         val content: String,
         val representativeAddress: String,
         val anonymous: Boolean,
-        val fromUser: QuestionUserDto,
-        val toUser: QuestionUserDto,
+        val fromUser: WriterUserDto,
+        val toUser: WriterUserDto,
         val createdAt: LocalDateTime,
     ) {
         companion object {
@@ -175,10 +174,10 @@ data class ReceivedQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress?: "",
+                    representativeAddress = question.representativeAddress,
                     anonymous = question.anonymous,
-                    fromUser = QuestionUserDto.from(question.fromUser),
-                    toUser = QuestionUserDto.from(question.toUser),
+                    fromUser = WriterUserDto.from(question.fromUser),
+                    toUser = WriterUserDto.from(question.toUser),
                     createdAt = question.createdAt,
                 )
             }
@@ -209,8 +208,8 @@ data class AskedQuestionsDto(
         val content: String,
         val representativeAddress: String,
         val anonymous: Boolean,
-        val fromUser: QuestionUserDto,
-        val toUser: QuestionUserDto,
+        val fromUser: WriterUserDto,
+        val toUser: WriterUserDto,
         val createdAt: LocalDateTime,
     ) {
         companion object {
@@ -218,10 +217,10 @@ data class AskedQuestionsDto(
                 return QuestionDto(
                     id = question.id.toHexString(),
                     content = question.content,
-                    representativeAddress = question.representativeAddress?: "",
+                    representativeAddress = question.representativeAddress,
                     anonymous = question.anonymous,
-                    fromUser = QuestionUserDto.from(question.fromUser),
-                    toUser = QuestionUserDto.from(question.toUser),
+                    fromUser = WriterUserDto.from(question.fromUser),
+                    toUser = WriterUserDto.from(question.toUser),
                     createdAt = question.createdAt,
                 )
             }
@@ -243,22 +242,3 @@ data class AskedQuestionsDto(
     }
 }
 
-data class QuestionUserDto(
-    val id: String,
-    val nickname: String,
-    val tags: List<String>,
-    val profileImageUrl: String?,
-    val level: Int
-) {
-    companion object {
-        fun from(user: QuestionUserDomain): QuestionUserDto {
-            return QuestionUserDto(
-                id = user.id.toHexString(),
-                nickname = user.nickname,
-                tags = user.tags,
-                profileImageUrl = user.profileImageUrl,
-                level = user.level
-            )
-        }
-    }
-}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/WriterUserDto.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/controller/dto/WriterUserDto.kt
@@ -1,0 +1,23 @@
+package kr.mashup.bangwidae.asked.controller.dto
+
+import kr.mashup.bangwidae.asked.model.domain.WriterUserDomain
+
+data class WriterUserDto(
+    val id: String,
+    val tags: List<String> = emptyList(),
+    val nickname: String,
+    val profileImageUrl: String?,
+    val level: Int
+) {
+    companion object {
+        fun from(user: WriterUserDomain): WriterUserDto {
+            return WriterUserDto(
+                id = user.id.toHexString(),
+                tags = user.tags,
+                nickname = user.nickname,
+                profileImageUrl = user.profileImageUrl,
+                level = user.level
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
@@ -25,6 +25,7 @@ enum class DoriDoriExceptionType(
     // USER
     DUPLICATED_NICKNAME("이미 존재하는 닉네임이에요"),
     USER_NOT_FOUND("유저를 찾을 수 없어요"),
+    USER_WITHDRAWN("탈퇴한 유저예요"),
 
     // PLACE
     INVALID_COUNTRY("한국에서만 위치 기능을 사용할 수 있어요"),

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/exception/DoriDoriExeptionType.kt
@@ -25,7 +25,7 @@ enum class DoriDoriExceptionType(
     // USER
     DUPLICATED_NICKNAME("이미 존재하는 닉네임이에요"),
     USER_NOT_FOUND("유저를 찾을 수 없어요"),
-    USER_WITHDRAWN("탈퇴한 유저예요"),
+    USER_DELETED("탈퇴한 유저예요"),
 
     // PLACE
     INVALID_COUNTRY("한국에서만 위치 기능을 사용할 수 있어요"),

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/document/User.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/document/User.kt
@@ -24,10 +24,11 @@ data class User(
     val profileImageUrl: String? = null,
     val refreshToken: String? = null,
     val settings: UserSettings = UserSettings(),
-
+    val deleted: Boolean = false,
+    val deletedAt: LocalDateTime? = null,
     @Version var version: Int? = null,
     @CreatedDate var createdAt: LocalDateTime? = null,
-    @LastModifiedDate var updatedAt: LocalDateTime? = null
+    @LastModifiedDate var updatedAt: LocalDateTime? = null,
 ) {
     fun updateNickname(nickname: String): User {
         return this.copy(
@@ -58,6 +59,10 @@ data class User(
         )
     }
 
+    fun deleteUser(): User {
+        return this.copy(deleted = true, deletedAt = LocalDateTime.now())
+    }
+
     fun getAnonymousUser(): User {
         return this.copy(nickname = "익명", profileImageUrl = DEFAULT_PROFILE_IMAGE_URL, level = 1)
     }
@@ -83,6 +88,14 @@ data class User(
                 loginType = LoginType.BASIC
             )
         }
+
+        fun deletedUser(): User = User(
+            id = ObjectId(),
+            email = "",
+            loginType = LoginType.BASIC,
+            nickname = "탈퇴한 사용자",
+            profileImageUrl = DEFAULT_PROFILE_IMAGE_URL
+        )
     }
 }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
@@ -20,12 +20,11 @@ data class CommentDomain(
         fun from(user: User, comment: Comment, likeCount: Int, userLiked: Boolean) = CommentDomain(
             id = comment.id!!,
             content = comment.content,
-            representativeAddress = comment.region?.representativeAddress?: "",
+            representativeAddress = comment.region?.representativeAddress ?: "",
             anonymous = comment.anonymous,
             createdAt = comment.createdAt,
             updatedAt = comment.updatedAt,
-            user = if (comment.anonymous) CommentUserDomain.from(user.getAnonymousUser())
-            else CommentUserDomain.from(user),
+            user = CommentUserDomain.of(user, comment.anonymous),
             likeCount = likeCount,
             userLiked = userLiked,
         )
@@ -47,5 +46,12 @@ data class CommentUserDomain(
             profileImageUrl = user.userProfileImageUrl,
             level = user.level
         )
+
+        fun of(user: User, anonymous: Boolean) =
+            when {
+                user.deleted -> from(User.deletedUser())
+                anonymous -> from(user.getAnonymousUser())
+                else -> from(user)
+            }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 
 data class CommentDomain(
     val id: ObjectId,
-    val user: CommentUserDomain,
+    val user: WriterUserDomain,
     val content: String,
     val likeCount: Int,
     val userLiked: Boolean,
@@ -24,34 +24,9 @@ data class CommentDomain(
             anonymous = comment.anonymous,
             createdAt = comment.createdAt,
             updatedAt = comment.updatedAt,
-            user = CommentUserDomain.of(user, comment.anonymous),
+            user = WriterUserDomain.of(user, comment.anonymous),
             likeCount = likeCount,
             userLiked = userLiked,
         )
-    }
-}
-
-data class CommentUserDomain(
-    val id: ObjectId,
-    val tags: List<String>,
-    val nickname: String,
-    val profileImageUrl: String,
-    val level: Int
-) {
-    companion object {
-        fun from(user: User) = CommentUserDomain(
-            id = user.id!!,
-            nickname = user.nickname!!,
-            tags = user.tags,
-            profileImageUrl = user.userProfileImageUrl,
-            level = user.level
-        )
-
-        fun of(user: User, anonymous: Boolean) =
-            when {
-                user.deleted -> from(User.deletedUser())
-                anonymous -> from(user.getAnonymousUser())
-                else -> from(user)
-            }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/CommentDomain.kt
@@ -11,7 +11,7 @@ data class CommentDomain(
     val content: String,
     val likeCount: Int,
     val userLiked: Boolean,
-    val representativeAddress: String,
+    val representativeAddress: String?,
     val anonymous: Boolean,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?
@@ -20,7 +20,7 @@ data class CommentDomain(
         fun from(user: User, comment: Comment, likeCount: Int, userLiked: Boolean) = CommentDomain(
             id = comment.id!!,
             content = comment.content,
-            representativeAddress = comment.region?.representativeAddress ?: "",
+            representativeAddress = comment.region?.representativeAddress,
             anonymous = comment.anonymous,
             createdAt = comment.createdAt,
             updatedAt = comment.updatedAt,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
@@ -25,14 +25,13 @@ data class PostDomain(
         fun from(user: User, post: Post, likeCount: Int, commentCount: Int, userLiked: Boolean) = PostDomain(
             id = post.id!!,
             content = post.content,
-            representativeAddress = post.representativeAddress?: "",
+            representativeAddress = post.representativeAddress ?: "",
             longitude = post.location.getLongitude(),
             latitude = post.location.getLatitude(),
             anonymous = post.anonymous,
             createdAt = post.createdAt,
             updatedAt = post.updatedAt,
-            user = if (post.anonymous) PostUserDomain.from(user.getAnonymousUser())
-            else PostUserDomain.from(user),
+            user = PostUserDomain.of(user, post.anonymous),
             likeCount = likeCount,
             commentCount = commentCount,
             userLiked = userLiked,
@@ -55,5 +54,12 @@ data class PostUserDomain(
             profileImageUrl = user.userProfileImageUrl,
             level = user.level
         )
+
+        fun of(user: User, anonymous: Boolean) =
+            when {
+                user.deleted -> from(User.deletedUser())
+                anonymous -> from(user.getAnonymousUser())
+                else -> from(user)
+            }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 data class PostDomain(
     val id: ObjectId,
-    val user: PostUserDomain,
+    val user: WriterUserDomain,
     val content: String,
     val likeCount: Int,
     val commentCount: Int,
@@ -31,35 +31,10 @@ data class PostDomain(
             anonymous = post.anonymous,
             createdAt = post.createdAt,
             updatedAt = post.updatedAt,
-            user = PostUserDomain.of(user, post.anonymous),
+            user = WriterUserDomain.of(user, post.anonymous),
             likeCount = likeCount,
             commentCount = commentCount,
             userLiked = userLiked,
         )
-    }
-}
-
-data class PostUserDomain(
-    val id: ObjectId,
-    val tags: List<String>,
-    val nickname: String,
-    val profileImageUrl: String,
-    val level: Int
-) {
-    companion object {
-        fun from(user: User) = PostUserDomain(
-            id = user.id!!,
-            nickname = user.nickname!!,
-            tags = user.tags,
-            profileImageUrl = user.userProfileImageUrl,
-            level = user.level
-        )
-
-        fun of(user: User, anonymous: Boolean) =
-            when {
-                user.deleted -> from(User.deletedUser())
-                anonymous -> from(user.getAnonymousUser())
-                else -> from(user)
-            }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/PostDomain.kt
@@ -16,7 +16,7 @@ data class PostDomain(
     val userLiked: Boolean,
     val longitude: Double,
     val latitude: Double,
-    val representativeAddress: String,
+    val representativeAddress: String?,
     val anonymous: Boolean,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?
@@ -25,7 +25,7 @@ data class PostDomain(
         fun from(user: User, post: Post, likeCount: Int, commentCount: Int, userLiked: Boolean) = PostDomain(
             id = post.id!!,
             content = post.content,
-            representativeAddress = post.representativeAddress ?: "",
+            representativeAddress = post.representativeAddress,
             longitude = post.location.getLongitude(),
             latitude = post.location.getLatitude(),
             anonymous = post.anonymous,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
@@ -27,11 +27,10 @@ data class QuestionDomain(
         ) = QuestionDomain(
             id = question.id!!,
             content = question.content,
-            representativeAddress = question.representativeAddress?: "",
+            representativeAddress = question.representativeAddress ?: "",
             anonymous = question.anonymous,
-            fromUser = if (question.anonymous) QuestionUserDomain.from(fromUser.getAnonymousUser())
-            else QuestionUserDomain.from(fromUser),
-            toUser = QuestionUserDomain.from(toUser),
+            fromUser = QuestionUserDomain.of(fromUser, question.anonymous),
+            toUser = QuestionUserDomain.of(toUser, false),
             answer = answer?.let {
                 AnswerDomain.from(
                     answer = it,
@@ -58,8 +57,8 @@ data class AnswerDomain(
         fun from(answer: Answer, user: User, likeCount: Long, userLiked: Boolean) = AnswerDomain(
             id = answer.id!!,
             content = answer.content,
-            representativeAddress = answer.representativeAddress?: "",
-            user = QuestionUserDomain.from(user),
+            representativeAddress = answer.representativeAddress ?: "",
+            user = QuestionUserDomain.of(user, false),
             likeCount = likeCount,
             userLiked = userLiked,
             createdAt = answer.createdAt!!,
@@ -82,5 +81,12 @@ data class QuestionUserDomain(
             profileImageUrl = user.userProfileImageUrl,
             level = user.level
         )
+
+        fun of(user: User, anonymous: Boolean) =
+            when {
+                user.deleted -> from(User.deletedUser())
+                anonymous -> from(user.getAnonymousUser())
+                else -> from(user)
+            }
     }
 }

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 data class QuestionDomain(
     val id: ObjectId,
     val content: String,
-    val representativeAddress: String,
+    val representativeAddress: String?,
     val anonymous: Boolean,
     val fromUser: WriterUserDomain,
     val toUser: WriterUserDomain,
@@ -27,7 +27,7 @@ data class QuestionDomain(
         ) = QuestionDomain(
             id = question.id!!,
             content = question.content,
-            representativeAddress = question.representativeAddress ?: "",
+            representativeAddress = question.representativeAddress,
             anonymous = question.anonymous,
             fromUser = WriterUserDomain.of(fromUser, question.anonymous),
             toUser = WriterUserDomain.of(toUser, false),
@@ -47,7 +47,7 @@ data class QuestionDomain(
 data class AnswerDomain(
     val id: ObjectId,
     val content: String,
-    val representativeAddress: String,
+    val representativeAddress: String?,
     val user: WriterUserDomain,
     val likeCount: Long,
     val userLiked: Boolean,
@@ -57,7 +57,7 @@ data class AnswerDomain(
         fun from(answer: Answer, user: User, likeCount: Long, userLiked: Boolean) = AnswerDomain(
             id = answer.id!!,
             content = answer.content,
-            representativeAddress = answer.representativeAddress ?: "",
+            representativeAddress = answer.representativeAddress,
             user = WriterUserDomain.of(user, false),
             likeCount = likeCount,
             userLiked = userLiked,

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/QuestionDomain.kt
@@ -11,8 +11,8 @@ data class QuestionDomain(
     val content: String,
     val representativeAddress: String,
     val anonymous: Boolean,
-    val fromUser: QuestionUserDomain,
-    val toUser: QuestionUserDomain,
+    val fromUser: WriterUserDomain,
+    val toUser: WriterUserDomain,
     val answer: AnswerDomain?,
     val createdAt: LocalDateTime,
 ) {
@@ -29,8 +29,8 @@ data class QuestionDomain(
             content = question.content,
             representativeAddress = question.representativeAddress ?: "",
             anonymous = question.anonymous,
-            fromUser = QuestionUserDomain.of(fromUser, question.anonymous),
-            toUser = QuestionUserDomain.of(toUser, false),
+            fromUser = WriterUserDomain.of(fromUser, question.anonymous),
+            toUser = WriterUserDomain.of(toUser, false),
             answer = answer?.let {
                 AnswerDomain.from(
                     answer = it,
@@ -48,7 +48,7 @@ data class AnswerDomain(
     val id: ObjectId,
     val content: String,
     val representativeAddress: String,
-    val user: QuestionUserDomain,
+    val user: WriterUserDomain,
     val likeCount: Long,
     val userLiked: Boolean,
     val createdAt: LocalDateTime,
@@ -58,7 +58,7 @@ data class AnswerDomain(
             id = answer.id!!,
             content = answer.content,
             representativeAddress = answer.representativeAddress ?: "",
-            user = QuestionUserDomain.of(user, false),
+            user = WriterUserDomain.of(user, false),
             likeCount = likeCount,
             userLiked = userLiked,
             createdAt = answer.createdAt!!,
@@ -66,27 +66,3 @@ data class AnswerDomain(
     }
 }
 
-data class QuestionUserDomain(
-    val id: ObjectId,
-    val nickname: String,
-    val tags: List<String>,
-    val profileImageUrl: String?,
-    val level: Int
-) {
-    companion object {
-        fun from(user: User) = QuestionUserDomain(
-            id = user.id!!,
-            nickname = user.nickname!!,
-            tags = user.tags,
-            profileImageUrl = user.userProfileImageUrl,
-            level = user.level
-        )
-
-        fun of(user: User, anonymous: Boolean) =
-            when {
-                user.deleted -> from(User.deletedUser())
-                anonymous -> from(user.getAnonymousUser())
-                else -> from(user)
-            }
-    }
-}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/WriterUserDomain.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/model/domain/WriterUserDomain.kt
@@ -1,0 +1,29 @@
+package kr.mashup.bangwidae.asked.model.domain
+
+import kr.mashup.bangwidae.asked.model.document.User
+import org.bson.types.ObjectId
+
+data class WriterUserDomain(
+    val id: ObjectId,
+    val nickname: String,
+    val tags: List<String>,
+    val profileImageUrl: String?,
+    val level: Int
+) {
+    companion object {
+        fun from(user: User) = WriterUserDomain(
+            id = user.id!!,
+            nickname = user.nickname!!,
+            tags = user.tags,
+            profileImageUrl = user.userProfileImageUrl,
+            level = user.level
+        )
+
+        fun of(user: User, anonymous: Boolean) =
+            when {
+                user.deleted -> from(User.deletedUser())
+                anonymous -> from(user.getAnonymousUser())
+                else -> from(user)
+            }
+    }
+}

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/repository/UserRepository.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/repository/UserRepository.kt
@@ -3,10 +3,12 @@ package kr.mashup.bangwidae.asked.repository
 import kr.mashup.bangwidae.asked.model.document.User
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.mongodb.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface UserRepository : MongoRepository<User, ObjectId> {
+    @Query("{'email' : ?0, 'deleted' : false}")
     fun findByEmail(email: String): User?
     fun findAllByIdIn(idList: Collection<ObjectId>): List<User>
     fun findByNickname(nickname: String): User?

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -64,7 +64,7 @@ class UserService(
     fun getUserInfo(userId: ObjectId): UserInfoDto {
         val user = userRepository.findById(userId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
-            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_WITHDRAWN) }
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_DELETED) }
 
         val representativeWard = wardService.getMyRepresentativeWard(user)
         return UserInfoDto.from(user, representativeWard)
@@ -109,7 +109,7 @@ class UserService(
     fun findById(id: ObjectId): User {
         return (userRepository.findByIdOrNull(id)
             ?: throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND))
-            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_WITHDRAWN) }
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_DELETED) }
     }
 
     fun findByEmail(email: String): User? {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -16,8 +16,8 @@ import kr.mashup.bangwidae.asked.service.question.QuestionService
 import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import org.springframework.web.multipart.MultipartFile
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 class UserService(
@@ -133,6 +133,10 @@ class UserService(
             locationInfo = editUserSettingsRequest.locationInfo,
         )
         return userRepository.save(user.updateSettings(newSettings))
+    }
+
+    fun delete(user: User) {
+        userRepository.save(user.deleteUser())
     }
 }
 

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -64,6 +64,8 @@ class UserService(
     fun getUserInfo(userId: ObjectId): UserInfoDto {
         val user = userRepository.findById(userId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+
         val representativeWard = wardService.getMyRepresentativeWard(user)
         return UserInfoDto.from(user, representativeWard)
     }
@@ -105,7 +107,9 @@ class UserService(
     }
 
     fun findById(id: ObjectId): User {
-        return userRepository.findByIdOrNull(id) ?: throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND)
+        return (userRepository.findByIdOrNull(id)
+            ?: throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND))
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
     }
 
     fun findByEmail(email: String): User? {

--- a/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
+++ b/src/main/kotlin/kr/mashup/bangwidae/asked/service/UserService.kt
@@ -64,7 +64,7 @@ class UserService(
     fun getUserInfo(userId: ObjectId): UserInfoDto {
         val user = userRepository.findById(userId)
             .orElseThrow { DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
-            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_WITHDRAWN) }
 
         val representativeWard = wardService.getMyRepresentativeWard(user)
         return UserInfoDto.from(user, representativeWard)
@@ -109,7 +109,7 @@ class UserService(
     fun findById(id: ObjectId): User {
         return (userRepository.findByIdOrNull(id)
             ?: throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND))
-            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_NOT_FOUND) }
+            .also { if (it.deleted) throw DoriDoriException.of(DoriDoriExceptionType.USER_WITHDRAWN) }
     }
 
     fun findByEmail(email: String): User? {


### PR DESCRIPTION
#179 
작업하다보니 뭔가 PostUserDomain, QuestionUserDomain, CommentUserDomain을 WriterUserDomain으로 합쳐버리고 싶은데... 이건 의견 들어보고 해야될거같아서 일단 안합치고 그대로 뒀습니당 (의견 오네가이시마스)..

그리고 유저삭제는 다른 도메인에서 버그가 발생하기도 쉬워보이고 삭제 로직에서 미처 커버 못한 케이스가 있을 수 있어서 천천히 머지하더라도 한번 꼼꼼히 봐주세용~
머지되더라도 버그 나오고 고치기 애매하면 바로 롤백하겠습니다~

작업내용
1. user delete 할때 soft delete할 수 있도록 deleted, deletedAt 필드 추가(deleted는 false로 기존 데이터 마이그레이션 완료)
2. user delete 하는 가라 api 에 삭제 로직 반영
3. User에 companion object로 삭제된 유저 달라고하는거 만들어두기(기존 유저에다가 copy 쓰기에는.. '삭제'된 유저이기 때문에 아예 따로 새로 가져오는게 맞다고 생각함)
4. PostUserDomain, QuestionUserDomain, CommentUserDomain 에서 user랑 anonymous 받아서 when절로 삭제된거니? -> deletedUser, 아니면 익명이니? -> anonymousUser, else니? -> User 로직 처리
5. deletedUser는 닉네임을 "탈퇴한 사용자" 로 내리기
6. 로그인할때 findByEmail 하면 없는 사용자로 나오게 findByEmail에 deleted 조건 추가
7. 가입할때 checkDuplicateUser할때 findByEmail하면 6번으로 인해 역시 가입안된 사용자라고 나와서 다시 같은 이메일로 가입 가능
8. 유저 id 받아서 처리하는거 있을때 deleted==true 이면 없는 사용자로 처리되게

### 삭제하고 다시 가입했을때 디비 상태
<img width="794" alt="image" src="https://user-images.githubusercontent.com/46064193/187031307-ef4ab076-fad7-49d7-b07c-6a7fd354cfc5.png">

### 삭제했을때 post 조회하면 이렇게 나옴
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/46064193/187031519-ce62024c-6394-4020-a943-1135b007a62c.png">

